### PR TITLE
Bugfix: on py2.7 only, to_bytes_32() would return less than 32 bytes for...

### DIFF
--- a/pycoin/encoding.py
+++ b/pycoin/encoding.py
@@ -65,7 +65,7 @@ def to_long(base, lookup_f, s):
             prefix += 1
     return v, prefix
 
-def from_long(v, prefix, base, charset):
+def from_long(v, prefix, base, charset, force_len=None):
     """The inverse of to_long. Convert an integer to an arbitrary base.
 
     v: the integer value to convert
@@ -81,11 +81,18 @@ def from_long(v, prefix, base, charset):
         except Exception:
             raise EncodingError("can't convert to character corresponding to %d" % mod)
     l.extend([charset(0)] * prefix)
+
+    if force_len is not None:
+        if len(l) < force_len:
+            l.extend([charset(0)] * (force_len - len(l)))
+        elif len(l) > force_len:
+            raise OverflowError()
+            
     l.reverse()
     return bytes(l)
 
 def to_bytes_32(v):
-    return from_long(v, 0, 256, lambda x: x)
+    return from_long(v, 0, 256, lambda x: x, force_len=32)
 
 if hasattr(int, "to_bytes"):
     to_bytes_32 = lambda v: v.to_bytes(32, byteorder="big")

--- a/pycoin/test/encoding_test.py
+++ b/pycoin/test/encoding_test.py
@@ -64,6 +64,10 @@ class EncodingTestCase(unittest.TestCase):
         do_test(b'\x74' * 10000,
             b'\xa9a\x07\x02\x96gt\x01\xa5~\xae\r\x96\xd1MZ\x88\n,A')
 
+    def test_to_bytes_32(self):
+        # Check a py2 vs py3 difference
+        self.assertEqual(encoding.to_bytes_32(65), bytearray(31) + bytearray('A'))
+
     def test_wif_to_from_secret_exponent(self):
         def do_test(as_secret_exponent, as_wif, is_compressed):
             self.assertEqual(as_wif, encoding.secret_exponent_to_wif(as_secret_exponent, compressed=is_compressed))


### PR DESCRIPTION
... any int < (2**256)

Pull includes failing test case. Would not happen on py3, and this fix and test case has not been tested on py3.

Lovely code BTW! :+1: 
