### PR TITLE
Don´t use distutils. Fixes #3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 *~
 dist
 build
+files.txt
+*egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: install uninstall
+
+install:
+	./setup.py install --record files.txt
+uninstall:
+	cat files.txt | xargs rm -rf

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import distutils.core
+from setuptools import setup
 
 version = "0.23"
 
-distutils.core.setup(
+setup(
     name="pycoin",
     version=version,
     packages = [


### PR DESCRIPTION
I have not only fixed issue number three here, but also included a Makefile that provides simplistic way to undo a system-wide installation.

```
vagrant@millstone:~/github/pycoin$ sudo make install
*snip*
Installed /usr/local/lib/python2.7/dist-packages/pycoin-0.23-py2.7.egg
Processing dependencies for pycoin==0.23
Finished processing dependencies for pycoin==0.23
writing list of installed files to 'files.txt'
vagrant@millstone:~/github/pycoin$ genwallet
usage: genwallet [-h] [-a] [-i] [-w] [-f WALLET_KEY_FILE] [-k WALLET_KEY] [-g]
                 [-u] [-n] [-p passphrase] [-s SUBKEY] [-t]
                 [inputfile]
genwallet: error: you must specify at least one source of entropy
vagrant@millstone:~/github/pycoin$ sudo make uninstall
cat files.txt | xargs rm -rf
vagrant@millstone:~/github/pycoin$ genwallet
bash: /usr/local/bin/genwallet: No such file or directory
```
