### PR TITLE
Switch from `/dev/urandom` to `/dev/random`

### DIFF
--- a/pycoin/scripts/genwallet.py
+++ b/pycoin/scripts/genwallet.py
@@ -12,7 +12,7 @@ def gpg_entropy():
     return output
 
 def dev_random_entropy():
-    return open("/dev/urandom", "rb").read(64)
+    return open("/dev/random", "rb").read(64)
 
 def b2h(b):
     return binascii.hexlify(b).decode("utf8")
@@ -26,7 +26,7 @@ def main():
     parser.add_argument('-f', "--wallet-key-file", help='initial wallet key', type=argparse.FileType('r'))
     parser.add_argument('-k', "--wallet-key", help='initial wallet key')
     parser.add_argument('-g', "--gpg", help='use gpg --gen-random to get additional entropy', action='store_true')
-    parser.add_argument('-u', "--dev-random", help='use /dev/urandom to get additional entropy', action='store_true')
+    parser.add_argument('-u', "--dev-random", help='use /dev/random to get additional entropy', action='store_true')
     parser.add_argument('-n', "--uncompressed", help='show in uncompressed form', action='store_true')
     parser.add_argument('-p', help='generate wallet key from passphrase. NOT RECOMMENDED', metavar='passphrase')
     parser.add_argument('-s', "--subkey", help='subkey path (example: 0p/2/1)')


### PR DESCRIPTION
From the linux man page (http://www.linuxmanpages.com/man4/random.4.php):

"When read, /dev/urandom device will return as many bytes as are requested. As a result, if there is not sufficient entropy in the entropy pool, the returned values are theoretically vulnerable to a cryptographic attack..."

Perhaps this is paranoia, but for something as critical as generating bitcoin wallet keys being extra cautious seems prudent. The downside is that when generating a large number of wallet keys dev/random could block (same link):

"When the entropy pool is empty, reads from /dev/random will block until additional environmental noise is gathered."

I did some non-scientific testing and found I was able to call dev_random_entropy() 10,000 times on my laptop from /dev/random and /dev/urandom in ~46 seconds each. I can't say if there would be blocking issues on a fresh-install of a VM (say that only has shell access) or if my script had called dev_random_entropy() 100x more times. Even if there were potential blocking issues, I think it'd be better to risk massive key generation being a little slow due to blocking vs being a little insecure. Of course users could always decide to use /dev/urandom if they didn't want to risk blocking, this is just changing the default/reference example.

Thanks for releasing such an awesome library (and blog) Richard, it's really great! Apologies if my comment is incorrect, you're much more knowledgeable on this topic than I am.
