### PR TITLE
Import itertools for subkeys_for_path.

### DIFF
--- a/pycoin/wallet.py
+++ b/pycoin/wallet.py
@@ -43,6 +43,7 @@ import binascii
 import hashlib
 import hmac
 import struct
+import itertools
 
 from . import ecdsa
 


### PR DESCRIPTION
Wallet.subkeys_for_path() raises a NameError. Importing itertools fixes it.
