### PR TITLE
Use low 's' values for signatures.

### DIFF
--- a/pycoin/ecdsa/ecdsa.py
+++ b/pycoin/ecdsa/ecdsa.py
@@ -73,6 +73,8 @@ def sign(generator, secret_exponent, val, k=None, entropy_generator=os.urandom):
     s = ( numbertheory.inverse_mod( k, n ) * \
           ( val + ( secret_exponent * r ) % n ) ) % n
     if s == 0: raise RuntimeError("amazingly unlucky random number s")
+    if s > G.order() / 2:
+        s = G.order() - s
     return (r, s)
 
 def public_pair_for_secret_exponent(generator, secret_exponent):

--- a/pycoin/test/ecdsa_test.py
+++ b/pycoin/test/ecdsa_test.py
@@ -12,6 +12,9 @@ class ECDSATestCase(unittest.TestCase):
             for v in val_list:
                 signature = sign(generator_secp256k1, secret_exponent, v)
                 r = verify(generator_secp256k1, public_point, v, signature)
+                # Check that the 's' value is 'low', to prevent possible transaction malleability as per
+                # https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures
+                assert signature[1] <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
                 assert r == True
                 signature = signature[0],signature[1]+1
                 r = verify(generator_secp256k1, public_point, v, signature)


### PR DESCRIPTION
As per https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures, using values of `s` bounded by `curve.order()/2` can help preventing transaction malleability, by making sure no one other than sender can make different signatures for the same transaction. Combined with additional bitcoind validation to be implemented for transactions with `nVersion=3` it prevents issues with transactions modified by third parties otherwise not having control over them.

This change enables this "low S values" behaviour by default in pycoin, without any additional configuration. I think it is important step for compatibility with `nVersion=3` and is a good idea to always do it, because there are no counterindications for it AFAICS.
