### PR TITLE
Expand netcode to 3-letter codes, add Blackcoin, related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ CoinSafe https://coinsafe.com/
 
 GreenAddress https://greenaddress.it/
 
+Coinkite https://coinkite.com/
+
 Email me at him@richardkiss.com to be added to this list.
 
 

--- a/pycoin/encoding.py
+++ b/pycoin/encoding.py
@@ -255,19 +255,27 @@ def hash160_sec_to_bitcoin_address(hash160_sec, address_prefix=b'\0'):
     """Convert the hash160 of a sec version of a public_pair to a Bitcoin address."""
     return b2a_hashed_base58(address_prefix + hash160_sec)
 
+def pubkey_address_to_hash160_sec_with_prefix(coin_address):
+    """
+    Convert a (typically) Bitcoin address back to the hash160_sec format and
+    also return the prefix byte, but do not check it. Useful for all cryptocoins.
+    """
+    blob = a2b_hashed_base58(coin_address)
+    if len(blob) != 21:
+        raise EncodingError("incorrect binary length (%d) for pubkey address %s" %
+                            (len(blob), coin_address))
+
+    return blob[1:], blob[:1]
 
 def bitcoin_address_to_hash160_sec_with_prefix(bitcoin_address):
     """
     Convert a Bitcoin address back to the hash160_sec format and
     also return the prefix.
     """
-    blob = a2b_hashed_base58(bitcoin_address)
-    if len(blob) != 21:
-        raise EncodingError("incorrect binary length (%d) for Bitcoin address %s" %
-                            (len(blob), bitcoin_address))
-    if blob[:1] not in [b'\x6f', b'\0']:
+    blob, prefix = pubkey_address_to_hash160_sec_with_prefix(bitcoin_address)
+    if prefix not in [b'\x6f', b'\0']:
         raise EncodingError("incorrect first byte (%s) for Bitcoin address %s" % (blob[0], bitcoin_address))
-    return blob[1:], blob[:1]
+    return blob, prefix
 
 
 def bitcoin_address_to_hash160_sec(bitcoin_address, address_prefix=b'\0'):

--- a/pycoin/key/Key.py
+++ b/pycoin/key/Key.py
@@ -12,7 +12,7 @@ from .bip32 import Wallet
 
 class Key(object):
     def __init__(self, hierarchical_wallet=None, secret_exponent=None,
-                 public_pair=None, hash160=None, prefer_uncompressed=None, is_compressed=True, netcode='M'):
+                 public_pair=None, hash160=None, prefer_uncompressed=None, is_compressed=True, netcode='BTC'):
         """
         hierarchical_wallet:
             a bip32 wallet

--- a/pycoin/key/bip32.py
+++ b/pycoin/key/bip32.py
@@ -77,7 +77,7 @@ class Wallet(object):
     https://en.bitcoin.it/wiki/BIP_0032
     """
     @classmethod
-    def from_master_secret(class_, master_secret, netcode='M'):
+    def from_master_secret(class_, master_secret, netcode='BTC'):
         """Generate a Wallet from a master password."""
         I64 = hmac.HMAC(key=b"Bitcoin seed", msg=master_secret, digestmod=hashlib.sha512).digest()
         return class_(

--- a/pycoin/networks.py
+++ b/pycoin/networks.py
@@ -1,26 +1,29 @@
 from .serialize import h2b
 from .encoding import EncodingError
 from collections import namedtuple
+from .block import Block, BitcoinBlock, BitcoinTestNetBlock, LitecoinBlock, BlackcoinBlock
 
 NetworkValues = namedtuple('NetworkValues', 
-    ('code', 'wif_prefix', 'address_prefix',
-        'bip32_priv_prefix', 'bip32_pub_prefix', 'network_name'))
+    ('code', 'network_name',
+        'wif_prefix', 'address_prefix',
+        'bip32_priv_prefix', 'bip32_pub_prefix',
+        'block_class'))
 
 NETWORKS = (
     # Bitcoin
-    NetworkValues("BTC", b'\x80', b'\0', h2b("0488ADE4"), h2b("0488B21E"), "Bitcoin"),
+    NetworkValues("BTC", "Bitcoin", b'\x80', b'\0', h2b("0488ADE4"), h2b("0488B21E"), BitcoinBlock),
 
     # Bitcoin Textnet3
-    NetworkValues("XTN", b'\xef', b'\x6f', h2b("04358394"), h2b("043587CF"), "Bitcoin testnet"),
+    NetworkValues("XTN", "Bitcoin testnet", b'\xef', b'\x6f', h2b("04358394"), h2b("043587CF"), BitcoinTestNetBlock),
 
     # Litecoin
-    NetworkValues("LTC", b'\xb0', b'\x30', None, None, "Litecoin"),
+    NetworkValues("LTC", "Litecoin", b'\xb0', b'\x30', None, None, LitecoinBlock),
 
     # Dogecoin
-    NetworkValues("DOGE", b'\x9e', b'\x1e', h2b("02fda4e8"), h2b("02fda923"), "Dogecoin"),
+    NetworkValues("DOGE", "Dogecoin", b'\x9e', b'\x1e', h2b("02fda4e8"), h2b("02fda923"), Block),
 
     # BlackCoin: unsure about bip32 prefixes; assuming will use Bitcoin's
-    NetworkValues("BLK", b'\x99', b'\x19', h2b("0488ADE4"), h2b("0488B21E"), "Blackcoin"),
+    NetworkValues("BLK", "Blackcoin", b'\x99', b'\x19', h2b("0488ADE4"), h2b("0488B21E"), BlackcoinBlock),
 )
 
 # Map from short code to details about that network.
@@ -46,6 +49,16 @@ def prv32_prefix_for_netcode(netcode):
 
 def pub32_prefix_for_netcode(netcode):
     return NETWORK_NAME_LOOKUP[netcode].bip32_pub_prefix
+
+def transaction_class_for_netcode(netcode):
+    # We need to know what class to use for the 
+    # transaction for some networks, but most can just use normal Tx
+    return NETWORK_NAME_LOOKUP[netcode].block_class.txn_class
+
+def block_class_for_netcode(netcode):
+    # We need to know what class to use for the blocks.
+    return NETWORK_NAME_LOOKUP[netcode].block_class
+
 
 
 def netcode_and_type_for_data(data):

--- a/pycoin/scripts/genwallet.py
+++ b/pycoin/scripts/genwallet.py
@@ -40,7 +40,7 @@ def main():
     if args.inputfile == sys.stdin:
         args.inputfile = sys.stdin.buffer
 
-    network = 'T' if args.t else 'M'
+    network = 'XTN' if args.t else 'BTC'
 
     entropy = bytearray()
     if args.gpg:

--- a/pycoin/scripts/ku.py
+++ b/pycoin/scripts/ku.py
@@ -275,8 +275,9 @@ def main():
             elif args.wif:
                 print(output_dict["wif_uncompressed" if args.uncompressed else "wif"])
             elif args.address:
-                print(output_dict[
-                    "bitcoin_address_uncompressed" if args.uncompressed else "bitcoin_address"])
+                addr = "%s_address" % key._netcode.lower()
+                print(output_dict[addr + "_uncompressed" 
+                                    if args.uncompressed else addr])
             else:
                 dump_output(output_dict, output_order)
 

--- a/pycoin/test/altcoins_test.py
+++ b/pycoin/test/altcoins_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import binascii
+import io
+import unittest
+
+from pycoin.block import BlackcoinBlock, LitecoinBlock
+from pycoin.serialize import h2b, b2h
+
+class AltcoinsTests(unittest.TestCase):
+
+    def test_blackcoin(self):
+        # Blackcoin block 114072, containing 2 txn. May 6th, 2014
+        block_114072_hash = 'f2580bd47b74df9739c1006fbae527348cd3a1bf720935d28a2b948e5a00f12e'
+        block_114072_raw = h2b('06000000a0f137457cd0a39400aa39b1ea54c92f8de3683a37de9cd3759cc2bed342644662b7887fa9ca5bf2bc0db76cdc04c1bf7941410982f00cb038448e9360eb2074340f6953463f0a1d000000000201000000340f6953010000000000000000000000000000000000000000000000000000000000000000ffffffff040398bd01ffffffff010000000000000000000000000001000000340f6953017c8d38dc95d74fe617bcdc65f7765e624bd0a15258f232df7d9013d38f6798360200000049483045022100ffc35355837100fe11e81a68180b53b8c80b3973003eb874252c905e57c2a9a7022057df38b4264565c8c9ce292fa8eb3eca5dbcf65d0db593f7ab60223274843e0401ffffffff020000000000000000007429c592a10000002321039a9402f6eb37e3365fc124ab0f461a5a164132b027430d1b0340cb5e81a2c59eac00000000463044022013cb127935dd38b67bde928b250ac6c532c8f1f3d9d0ce88fe44899f93a3a1aa02203a7e69a2c033fbbbbef742fa63fb244f2c07098794a7b1de2b893d24f30b0b65')
+        block_114072_sig = h2b('3044022013cb127935dd38b67bde928b250ac6c532c8f1f3d9d0ce88fe44899f93a3a1aa02203a7e69a2c033fbbbbef742fa63fb244f2c07098794a7b1de2b893d24f30b0b65')
+
+        blk = BlackcoinBlock.parse(io.BytesIO(block_114072_raw))
+
+        self.assertEqual(len(blk.txs), 2)
+        self.assertEqual(blk.netcode, 'BLK')
+        self.assertEqual(blk.id(), block_114072_hash)
+        self.assertEqual(blk.block_sig, block_114072_sig)
+
+        self.assertEqual(blk.txs[0].id(),
+                '834e501292983cfcc249a2f6693395ff1be1eddda8065e610fabad806d639601')
+        self.assertEqual(blk.txs[1].id(),
+                'd3fe93274c49d30637ceb7b4033d7e7f42e82d75723b0268a646d6bb5495873a')
+        self.assertEqual(blk.txs[0].netcode, 'BLK')
+
+        # test special "mined time" value stored in Tx header
+        # 1399394100 == "Tue May  6 12:35:00 2014"
+        self.assertEqual(blk.txs[0].mined_time, 1399394100)
+        self.assertEqual(blk.txs[1].mined_time, 1399394100)
+
+        with io.BytesIO() as s:
+            blk.stream(s)
+            regen = s.getvalue()
+        self.assertEqual(block_114072_raw, regen)
+
+        with self.assertRaises(NotImplementedError):
+            blk.block_sig = None
+            with io.BytesIO() as s:
+                blk.stream(s)
+
+    def test_litecoin(self):
+        # Litecoin block #562399  http://ltc.blockr.io/block/info/562399
+        # just 3 txn! 
+        b_hash = 'e8cfa021a51d33dcfdfa7e9aeb9f5a00aa42e86d8ea0cb3479319f773e1f4eb5'
+        b_raw = h2b('020000000c724ece8d59a630efddf53311ed508a1db828ec00973194c4ec4367e6298baec468a155a4c8a64b737216f603e2a49ee49ff991da40f5dd93cc538b7ec94f74fe17695337ee081ba684b5290301000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2303df9408062f503253482f04e6176953080802ed8c24000000092f7374726174756d2f000000000100f2052a010000001976a914eda916237d9d8b46baa76f697b6c9343e45ed2de88ac0000000001000000019f1045512c0b48f7ea54c4895f34051d1ff47362033ada7603b7f7363cad7e87010000006b4830450221009b8f7f5d51d01c565bed36b0d821643cec3cdacf64525f0db92a5a3f898283cb02206471601caa83d156c823057ef66406b6e16c4566210b3dc95651780c00a3b39401210245c3a34148870dc9a7803c698d21dd6532d82626d78d16d40158763c3a566f16ffffffff01be952aa0010000001976a914cf13eb08302b6f55d6ba99654de132ad3b67ab2e88ac000000000100000002abc1249f7f4258c1593b7da45248469292ac99f185585b8391f68746e7abfaa6010000006b483045022100809af5f0a51c188b3b0a13f9da03393efd77249c2d633b4638f1d26c0c7d0a69022007d1fb113e8c7a95f4ebe2fc30fa91f413bdb3c13cff44b7adb6ba3c4dde6c83012102da69e08e7fc11f6bee0286ff0e8114ee8120a55c47719fa2a07951097a2db7b3ffffffff51a1cd456513e04c55dbffeed86ff7c1a312302897b0ec67aaab49ba25f26f45010000006b48304502207f15f1e0b71c0cc6c35194d8cd83502e42fec045cde074ea34d244112ec65187022100a551d30472eda95e58beafb60d35c77d3047e8a1942d7dda6aec4312888afc0d0121026ea3a12ea83231142ebc825243c141ecd7c267116d84dacc08907c6d067a525affffffff01dae8cf15000000001976a9142a546e72b7d844b098427ce750c21addf62a50bd88ac00000000')
+
+        blk = LitecoinBlock.parse(io.BytesIO(b_raw))
+
+        self.assertEqual(len(blk.txs), 3)
+        self.assertEqual(blk.netcode, 'LTC')
+        self.assertEqual(blk.id(), b_hash)
+
+        self.assertEqual(blk.txs[0].netcode, 'LTC')
+
+        for i, hh in enumerate((
+                    'a8b631ddbcd1b4744cd355b02036ecf8208150177b7a5d2ef44a122949c402e3',
+                    '0661d8bdd79137a888292430961c5e614d8bfb775a6693f18ac7f5b6392c0e9f',
+                    '7ab578695dc354898ce1fc5e27110444b6802e5141f0b555b4e4e2576679c0aa')):
+            self.assertEqual(blk.txs[i].id(), hh)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pycoin/test/bip32_test.py
+++ b/pycoin/test/bip32_test.py
@@ -106,7 +106,7 @@ class Bip0032TestCase(unittest.TestCase):
 
     def test_testnet(self):
         # WARNING: these values have not been verified independently. TODO: do so
-        master = bip32.Wallet.from_master_secret(h2b("000102030405060708090a0b0c0d0e0f"), netcode='T')
+        master = bip32.Wallet.from_master_secret(h2b("000102030405060708090a0b0c0d0e0f"), netcode='XTN')
         self.assertEqual(master.wallet_key(as_private=True), "tprv8ZgxMBicQKsPeDgjzdC36fs6bMjGApWDNLR9erAXMs5skhMv36j9MV5ecvfavji5khqjWaWSFhN3YcCUUdiKH6isR4Pwy3U5y5egddBr16m")
         self.assertEqual(master.bitcoin_address(), "mkHGce7dctSxHgaWSSbmmrRWsZfzz7MxMk")
         self.assertEqual(master.wif(), "cVPXTF2TnozE1PenpP3x9huctiATZmp27T9Ue1d8nqLSExoPwfN5")

--- a/pycoin/test/build_tx_test.py
+++ b/pycoin/test/build_tx_test.py
@@ -169,6 +169,8 @@ class BuildTxTest(unittest.TestCase):
         tx_out = TxOut(coin_value, p2sh_tx_out_script(recipient_p2sh))
         s = str(tx_out)
         self.assertEqual('TxOut<0.0003 mbtc "OP_HASH160 379ad9b7ba73bdc1e29e286e014d4e2e1f6884e3 OP_EQUAL">', s)
+        # test decode of script, back into (testnet) P2SH address
+        self.assertEqual(tx_out.bitcoin_address(chr(196)), recipient_p2sh)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pycoin/test/build_tx_test.py
+++ b/pycoin/test/build_tx_test.py
@@ -11,7 +11,7 @@ from pycoin.serialize import h2b
 
 from pycoin.tx import Tx, SIGHASH_ALL
 from pycoin.tx.TxIn import TxIn
-from pycoin.tx.TxOut import TxOut, standard_tx_out_script
+from pycoin.tx.TxOut import TxOut, standard_tx_out_script, p2sh_tx_out_script
 from pycoin.tx.script.solvers import build_hash160_lookup_db
 
 
@@ -161,6 +161,14 @@ class BuildTxTest(unittest.TestCase):
 
         # now check that it validates
         self.assertEqual(spend_tx.bad_signature_count(), 0)
+
+    def test_p2sh_tx_out(self):
+        # from https://people.xiph.org/~greg/escrowexample.txt
+        coin_value = 30
+        recipient_p2sh = '2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7'
+        tx_out = TxOut(coin_value, p2sh_tx_out_script(recipient_p2sh))
+        s = str(tx_out)
+        self.assertEqual('TxOut<0.0003 mbtc "OP_HASH160 379ad9b7ba73bdc1e29e286e014d4e2e1f6884e3 OP_EQUAL">', s)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pycoin/test/encoding_test.py
+++ b/pycoin/test/encoding_test.py
@@ -3,6 +3,7 @@
 import unittest
 
 from pycoin import encoding
+from pycoin.serialize import h2b
 
 class EncodingTestCase(unittest.TestCase):
 
@@ -11,8 +12,8 @@ class EncodingTestCase(unittest.TestCase):
             self.assertEqual((as_int, prefix), encoding.to_long(base, encoding.byte_to_int, as_rep))
             self.assertEqual(as_rep, encoding.from_long(as_int, prefix, base, lambda v:v))
 
-        do_test(10000101, 2, encoding.h2b("00009896e5"), 256)
-        do_test(10000101, 3, encoding.h2b("0000009896e5"), 256)
+        do_test(10000101, 2, h2b("00009896e5"), 256)
+        do_test(10000101, 3, h2b("0000009896e5"), 256)
         do_test(1460765565493402645157733592332121663123460211377, 1, b'\0\xff\xde\xfeOHu\xcf\x11\x9f\xc3\xd8\xf4\xa0\x9a\xe3~\xc4\xccB\xb1', 256)
 
     def test_to_bytes_32(self):
@@ -162,7 +163,7 @@ class EncodingTestCase(unittest.TestCase):
         ]
 
         for public_pair, sec, compressed, hash160_sec, bitcoin_address in SEC_TEST_DATA:
-            do_test(public_pair, encoding.h2b(sec), compressed, encoding.h2b(hash160_sec), bitcoin_address)
+            do_test(public_pair, h2b(sec), compressed, h2b(hash160_sec), bitcoin_address)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 import io
 from time import time as unix_time
+from copy import deepcopy
 
 from ..encoding import double_sha256, from_bytes_32
 from ..serialize import b2h, b2h_rev, h2b, h2b_rev
@@ -189,7 +190,11 @@ class Tx(object):
         if hash_type & SIGHASH_ANYONECANPAY:
             txs_in = [txs_in[unsigned_txs_out_idx]]
 
-        tmp_tx = self.__class__(self.version, txs_in, txs_out, self.lock_time)
+        # Because we don't know what metadata subclasses may be storing for this
+        # transaction, do not construct a new instance here. Instead, do a deepcopy
+        # and change the parts we need... then use that to calculate a hash.
+        tmp_tx = deepcopy(self)
+        tmp_tx.txs_in, tmp_tx.txs_out = txs_in, txs_out
         return from_bytes_32(tmp_tx.hash(hash_type=hash_type))
 
     def sign_tx_in(self, hash160_lookup, tx_in_idx, tx_out_script, hash_type=SIGHASH_ALL):

--- a/pycoin/tx/TxOut.py
+++ b/pycoin/tx/TxOut.py
@@ -68,3 +68,11 @@ def standard_tx_out_script(coin_address):
     hash160, prefix = pubkey_address_to_hash160_sec_with_prefix(coin_address)
     script_text = STANDARD_SCRIPT_OUT % b2h(hash160)
     return tools.compile(script_text)
+
+def p2sh_tx_out_script(p2sh_address):
+    # See BIP0016: https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
+    P2SH_SCRIPT_OUT = "OP_HASH160 %s OP_EQUAL"
+    hash160, prefix = pubkey_address_to_hash160_sec_with_prefix(p2sh_address)
+    script_text = P2SH_SCRIPT_OUT % b2h(hash160)
+    return tools.compile(script_text)
+

--- a/pycoin/tx/TxOut.py
+++ b/pycoin/tx/TxOut.py
@@ -27,7 +27,7 @@ THE SOFTWARE.
 """
 
 from ..convention import satoshi_to_mbtc
-from ..encoding import bitcoin_address_to_hash160_sec_with_prefix, hash160_sec_to_bitcoin_address
+from ..encoding import pubkey_address_to_hash160_sec_with_prefix, hash160_sec_to_bitcoin_address
 
 from ..serialize import b2h
 from ..serialize.bitcoin_streamer import parse_struct, stream_struct
@@ -63,8 +63,8 @@ class TxOut(object):
         return hash160_for_script(self.script)
 
 
-def standard_tx_out_script(bitcoin_address):
+def standard_tx_out_script(coin_address):
     STANDARD_SCRIPT_OUT = "OP_DUP OP_HASH160 %s OP_EQUALVERIFY OP_CHECKSIG"
-    hash160, prefix = bitcoin_address_to_hash160_sec_with_prefix(bitcoin_address)
+    hash160, prefix = pubkey_address_to_hash160_sec_with_prefix(coin_address)
     script_text = STANDARD_SCRIPT_OUT % b2h(hash160)
     return tools.compile(script_text)

--- a/pycoin/tx/__init__.py
+++ b/pycoin/tx/__init__.py
@@ -27,6 +27,6 @@ THE SOFTWARE.
 """
 
 from .Spendable import Spendable
-from .Tx import Tx, ValidationFailureError
+from .Tx import Tx, ValidationFailureError, ProofOfStakeTx
 from .Tx import SIGHASH_ALL, SIGHASH_NONE, SIGHASH_SINGLE, SIGHASH_ANYONECANPAY
 from .TxOut import TxOut

--- a/pycoin/tx/script/solvers.py
+++ b/pycoin/tx/script/solvers.py
@@ -42,6 +42,7 @@ bytes_from_int = chr if bytes == str else lambda x: bytes([x])
 TEMPLATES = [
     tools.compile("OP_PUBKEY OP_CHECKSIG"),
     tools.compile("OP_DUP OP_HASH160 OP_PUBKEYHASH OP_EQUALVERIFY OP_CHECKSIG"),
+    tools.compile("OP_HASH160 OP_PUBKEYHASH OP_EQUAL"),
 ]
 
 class SolvingError(Exception): pass

--- a/test-py2.7.sh
+++ b/test-py2.7.sh
@@ -9,3 +9,4 @@ python -m unittest pycoin.test.parse_block_test
 python -m unittest pycoin.test.signature_test
 python -m unittest pycoin.test.validate_tx_test
 python -m unittest pycoin.test.bip32_test
+python -m unittest pycoin.test.altcoins_test


### PR DESCRIPTION
As discussed in issue #29:
- network codes expanded to 3/4 letters
- `network.py` heavily reworked
- added values for "Blackcoin" as "BLK" although they use "BC" on the exchanges.
- `ku` script updated to handle new feature
- added Coinkite to users list (old news, used pycoin from day 1)
- import bug in testing code fixed
