### PR TITLE
fixes #39 - corrects signature_hash for SIGHASH_SINGLE on input index > 0; ...

### DIFF
--- a/pycoin/serialize/bitcoin_streamer.py
+++ b/pycoin/serialize/bitcoin_streamer.py
@@ -40,7 +40,6 @@ STREAMER_FUNCTIONS = {
     "S": (parse_bc_string, stream_bc_string),
     "h": (lambda f: struct.unpack("!H", f.read(2))[0], lambda f, v: f.write(struct.pack("!H", v))),
     "L": (lambda f: struct.unpack("<L", f.read(4))[0], lambda f, v: f.write(struct.pack("<L", v))),
-    "q": (lambda f: struct.unpack("<q", f.read(8))[0], lambda f, v: f.write(struct.pack("<q", v))),
     "Q": (lambda f: struct.unpack("<Q", f.read(8))[0], lambda f, v: f.write(struct.pack("<Q", v))),
     "#": (lambda f: f.read(32), lambda f, v: f.write(v[:32])),
     "@": (lambda f: f.read(16), lambda f, v: f.write(v[:16])),

--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -175,7 +175,7 @@ class Tx(object):
             # any outputs after this one and set all outputs before this
             # one to "null" (where "null" means an empty script and a
             # value of -1)
-            txs_out = [TxOut(-1, b'')] * unsigned_txs_out_idx
+            txs_out = [TxOut(0xffffffffffffffff, b'')] * unsigned_txs_out_idx
             txs_out.append(self.txs_out[unsigned_txs_out_idx])
 
             # Let the others update at will

--- a/pycoin/tx/TxOut.py
+++ b/pycoin/tx/TxOut.py
@@ -45,11 +45,11 @@ class TxOut(object):
         self.script = script
 
     def stream(self, f):
-        stream_struct("qS", f, self.coin_value, self.script)
+        stream_struct("QS", f, self.coin_value, self.script)
 
     @classmethod
     def parse(self, f):
-        return self(*parse_struct("qS", f))
+        return self(*parse_struct("QS", f))
 
     def __str__(self):
         return 'TxOut<%s mbtc "%s">' % (satoshi_to_mbtc(self.coin_value), tools.disassemble(self.script))


### PR DESCRIPTION
...adds ability to verify legacy SINGLE_HASH transactions; adds TxIn to tx/**init**.py for consistency with Tx and TxOut

Hopefully this fix for issue #39 helps redeem me from the utter embarrassment that is issue #38. :o(

I wrote a [test script](https://gist.github.com/mbogosian/fe35ef43e2cb4e8c2258) to compare the fixed output of `pycoin` with the equivalent output from `bitcoinj`. The python half is adapted as a (now working) unit test in e8b026f.

On a related note, your `BRAIN DAMAGE: this probably doesn't work right` comment was wrong...that part of the code was fine. It just required a number encoding tweak.... :o)
