### PR TITLE
Fix NetworkValues prefixes for litecoin

### DIFF
--- a/pycoin/networks.py
+++ b/pycoin/networks.py
@@ -10,8 +10,8 @@ NETWORKS = (
     NetworkValues("Bitcoin", "mainnet", "BTC", b'\x80', b'\0', b'\5', h2b("0488ADE4"), h2b("0488B21E")),
     NetworkValues("Bitcoin", "testnet3", "XTN", b'\xef', b'\x6f', b'\xc4',
                   h2b("04358394"), h2b("043587CF")),
-    NetworkValues("Litecoin", "mainnet", "LTC", b'\xb0', b'\x30', None, h2b('019d9cfe'), h2b('019da462')),
-    NetworkValues("Litecoin", "testnet", "XLT", b'\xb1', b'\x31', None, h2b('0436ef7d'), h2b('0436f6e1')),
+    NetworkValues("Litecoin", "mainnet", "LTC", b'\xb0', b'\x30', b'\5', h2b('019d9cfe'), h2b('019da462')),
+    NetworkValues("Litecoin", "testnet", "XLT", b'\xef', b'\x6f', b'\xc4', h2b('0436ef7d'), h2b('0436f6e1')),
     NetworkValues("Dogecoin", "mainnet", "DOGE", b'\x9e', b'\x1e', b'\x16',
                   h2b("02fda4e8"), h2b("02fda923")),
     # BlackCoin: unsure about bip32 prefixes; assuming will use Bitcoin's


### PR DESCRIPTION
Incorrect values are defined for litecoin testnet for the private and public key prefixes. The pay_to_script value is missing for both litecoin mainnet and testnet. This pull request changes the prefixes to conform to the values defined in litecoin.

https://github.com/litecoin-project/litecoin/blob/master-0.8/src/base58.h#L277
