### PR TITLE
Check lengths of DER signaures

### DIFF
--- a/pycoin/tx/script/der.py
+++ b/pycoin/tx/script/der.py
@@ -68,6 +68,8 @@ def remove_integer(string):
         raise UnexpectedDER("wanted integer (0x02), got 0x%02x" %
                             ord(string[:1]))
     length, llen = read_length(string[1:])
+    if len(string) < 1+llen+length:
+        raise UnexpectedDER("ran out of integer bytes")
     numberbytes = string[1+llen:1+llen+length]
     rest = string[1+llen+length:]
     assert ord(numberbytes[:1]) < 0x80 # can't support negative numbers yet


### PR DESCRIPTION
Currently pycoin allows passing truncated signatures to `sigdecode_der` which causes some invalid signatures to be decoded.

This patch adds a check for missing integer bytes which raises UnexpectedDER in case a signature is truncated.

Tested manually with some valid DER `signature` and `signature[:-1]` - the missing byte causes the exception to be raised correctly.
