### PR TITLE
Fix an endian issue

### DIFF
--- a/pycoin/tx/script/tools.py
+++ b/pycoin/tx/script/tools.py
@@ -43,7 +43,6 @@ else:
         while v > 0:
             v, mod = divmod(v, 256)
             l.append(mod)
-        l.reverse()
         return bytes(l)
 
 if hasattr(int, "from_bytes"):

--- a/tests/validate_tx_test.py
+++ b/tests/validate_tx_test.py
@@ -182,5 +182,11 @@ W4iswJ7mBQAAAAAZdqkU4E5+Is4tr+8bPU6ELYHSvz/Ng0eIrAAAAAA=
         tx_to_validate.unspents_from_db(TX_DB)
         self.assertEqual(tx_to_validate.bad_signature_count(), 0)
 
+    def test_endian(self):
+        from pycoin.tx.script.tools import bytes_to_int, int_to_bytes
+        assert bytes_to_int(int_to_bytes(768)) == 768
+        assert bytes_to_int(int_to_bytes(3)) == 3
+        assert bytes_to_int(int_to_bytes(66051)) == 66051
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Under python < 3, the endian of encoded bytes was wrong. This means broken transactions if PUSHDATA2 happens to be used.
