### PR TITLE
Fix #77. Add second `script` parameter to remaining `signature_for_hash_type_f` in `verify_tx_in`.

### DIFF
--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -250,7 +250,7 @@ class Tx(object):
 
     def verify_tx_in(self, tx_in_idx, tx_out_script, expected_hash_type=None):
         tx_in = self.txs_in[tx_in_idx]
-        signature_for_hash_type_f = lambda hash_type: self.signature_hash(tx_out_script, tx_in_idx, hash_type)
+        signature_for_hash_type_f = lambda hash_type, script: self.signature_hash(script, tx_in_idx, hash_type)
         if not tx_in.verify(tx_out_script, signature_for_hash_type_f, expected_hash_type):
             raise ValidationFailureError(
                 "just signed script Tx %s TxIn index %d did not verify" % (

--- a/pycoin/tx/script/vm.py
+++ b/pycoin/tx/script/vm.py
@@ -118,7 +118,7 @@ def eval_script(script, signature_for_hash_type_f, expected_hash_type=None, stac
                 sig_pair, signature_type = parse_signature_blob(stack.pop())
                 if expected_hash_type not in (None, signature_type):
                     raise ScriptError("wrong hash type")
-                signature_hash = signature_for_hash_type_f(signature_type, script=script)
+                signature_hash = signature_for_hash_type_f(signature_type, script)
                 if ecdsa.verify(ecdsa.generator_secp256k1, public_pair, signature_hash, sig_pair):
                     stack.append(VCH_TRUE)
                 else:
@@ -151,7 +151,7 @@ def eval_script(script, signature_for_hash_type_f, expected_hash_type=None, stac
                 sig_ok = VCH_TRUE
                 for sig_blob in sig_blobs:
                     sig_pair, signature_type = parse_signature_blob(sig_blob)
-                    signature_hash = signature_for_hash_type_f(signature_type, script=script)
+                    signature_hash = signature_for_hash_type_f(signature_type, script)
 
                     ppp = ecdsa.possible_public_pairs_for_signature(
                         ecdsa.generator_secp256k1, signature_hash, sig_pair)


### PR DESCRIPTION
***WARNING: THIS NEEDS REVIEW!***

It probably also needs unit tests.

I'm not sure I follow all the logic that motivated the original change in c441ea75885167a809ae402d03e1066ed89d3804, so I'm probably not the best person to submit this patch. @richardkiss and @gitmarek, can you give your blessing on this? Better yet, can either of you submit a unit test that will appropriately fail with 412efbced6852b586bca8ba2f34f124c974b29c4 and/or c441ea75885167a809ae402d03e1066ed89d3804 with respect to #77?