### PR TITLE
add kwarg to disable dummy signatures in ScriptMultisig

### DIFF
--- a/pycoin/tx/pay_to/ScriptMultisig.py
+++ b/pycoin/tx/pay_to/ScriptMultisig.py
@@ -86,6 +86,8 @@ class ScriptMultisig(ScriptType):
         sign_value = kwargs.get("sign_value")
         signature_type = kwargs.get("signature_type")
 
+        dummy_fill = kwargs.get("dummy_fill", True)
+
         secs_solved = set()
         existing_signatures = []
         existing_script = kwargs.get("existing_script")
@@ -121,9 +123,11 @@ class ScriptMultisig(ScriptType):
             secret_exponent, public_pair, compressed = result
             binary_signature = self._create_script_signature(secret_exponent, sign_value, signature_type)
             existing_signatures.append(binary_signature)
-        DUMMY_SIGNATURE = self._dummy_signature(signature_type)
-        while len(existing_signatures) < self.n:
-            existing_signatures.append(DUMMY_SIGNATURE)
+
+        if dummy_fill:
+            DUMMY_SIGNATURE = self._dummy_signature(signature_type)
+            while len(existing_signatures) < self.n:
+                existing_signatures.append(DUMMY_SIGNATURE)
 
         script = "OP_0 %s" % " ".join(b2h(s) for s in existing_signatures)
         solution = tools.compile(script)


### PR DESCRIPTION
when partially signing transactions and then sending it to other software to add more signatures some libraries don't deal well with the dummy signatures, so being able to disable the dummy signatures.