### PR TITLE
READY FOR REVIEW - Fix #89. Have pycoin log to its own named logger (based on the module name)...

### DIFF
--- a/pycoin/blockchain/BlockChain.py
+++ b/pycoin/blockchain/BlockChain.py
@@ -4,8 +4,8 @@ import weakref
 from .ChainFinder import ChainFinder
 from ..serialize import b2h_rev
 
+logger = logging.getLogger(__name__)
 ZERO_HASH = b'\0' * 32
-
 
 def _update_q(q, ops):
     # first, we meld out complimentary adds and removes
@@ -156,10 +156,10 @@ class BlockChain(object):
             old_path = old_longest_chain
             new_path = new_longest_chain
         if old_path:
-            logging.debug("old_path is %r-%r", old_path[0], old_path[-1])
+            logger.debug("old_path is %r-%r", old_path[0], old_path[-1])
         if new_path:
-            logging.debug("new_path is %r-%r", new_path[0], new_path[-1])
-            logging.debug("block chain now has %d elements", self.length())
+            logger.debug("new_path is %r-%r", new_path[0], new_path[-1])
+            logger.debug("block chain now has %d elements", self.length())
 
         # return a list of operations:
         # ("add"/"remove", the_hash, the_index)

--- a/pycoin/blockchain/BlockChain.py
+++ b/pycoin/blockchain/BlockChain.py
@@ -7,6 +7,7 @@ from ..serialize import b2h_rev
 logger = logging.getLogger(__name__)
 ZERO_HASH = b'\0' * 32
 
+
 def _update_q(q, ops):
     # first, we meld out complimentary adds and removes
     while len(ops) > 0:

--- a/pycoin/network/message.py
+++ b/pycoin/network/message.py
@@ -1,13 +1,14 @@
 import binascii
 import logging
 import io
-import struct
 
 from .InvItem import InvItem
 from .PeerAddress import PeerAddress
 from ..block import Block, BlockHeader
 from ..serialize import bitcoin_streamer
 from ..tx.Tx import Tx
+
+logger = logging.getLogger(__name__)
 
 # ## definitions of message structures and types
 # L: 4 byte long integer
@@ -112,7 +113,7 @@ def _make_parse_from_data():
             if fixup:
                 d = fixup(d, message_stream)
         else:
-            logging.error("unknown message: %s %s", message_name, binascii.hexlify(data))
+            logger.error("unknown message: %s %s", message_name, binascii.hexlify(data))
             d = {}
         return d
     return parse_from_data

--- a/pycoin/services/insight.py
+++ b/pycoin/services/insight.py
@@ -5,11 +5,11 @@ import decimal
 import json
 import logging
 
-
 try:
-    from urllib2 import urlopen
+    from urllib2 import ( HTTPError, urlopen )
 except ImportError:
     from urllib.request import urlopen
+    from urllib.error import HTTPError
 
 from pycoin.block import BlockHeader
 from pycoin.convention import btc_to_satoshi
@@ -19,6 +19,7 @@ from pycoin.serialize import b2h, b2h_rev, h2b, h2b_rev
 from pycoin.tx.script import tools
 from pycoin.tx import Spendable, Tx, TxIn, TxOut
 
+logger = logging.getLogger(__name__)
 
 class InsightService(object):
     def __init__(self, base_url):
@@ -101,7 +102,7 @@ class InsightService(object):
             d = urlopen(URL, data=data).read()
             return d
         except HTTPError as ex:
-            logging.exception("problem in send_tx %s", tx.id())
+            logger.exception("problem in send_tx %s", tx.id())
             raise ex
 
 

--- a/pycoin/services/insight.py
+++ b/pycoin/services/insight.py
@@ -5,6 +5,7 @@ import decimal
 import json
 import logging
 
+
 try:
     from urllib2 import ( HTTPError, urlopen )
 except ImportError:

--- a/pycoin/tx/script/tools.py
+++ b/pycoin/tx/script/tools.py
@@ -34,6 +34,7 @@ import struct
 from .opcodes import OPCODE_TO_INT, INT_TO_OPCODE
 from ...intbytes import bytes_from_int, bytes_to_ints, int_to_bytes, int_from_bytes
 
+logger = logging.getLogger(__name__)
 
 def get_opcode(script, pc):
     """Step through the script, returning a tuple with the next opcode, the next
@@ -112,7 +113,7 @@ def opcode_list(script):
             opcodes.append(binascii.hexlify(data).decode("utf8"))
             continue
         if not opcode in INT_TO_OPCODE:
-            logging.info("missing opcode %r", opcode)
+            logger.info("missing opcode %r", opcode)
             continue
         opcodes.append(INT_TO_OPCODE[opcode])
     return opcodes

--- a/pycoin/tx/script/vm.py
+++ b/pycoin/tx/script/vm.py
@@ -39,6 +39,8 @@ from . import ScriptError
 from .microcode import MICROCODE_LOOKUP, VCH_TRUE, VCH_FALSE, make_bool
 from .tools import get_opcode, bin_script
 
+logger = logging.getLogger(__name__)
+
 VERIFY_OPS = frozenset((opcodes.OPCODE_TO_INT[s] for s in "OP_NUMEQUALVERIFY OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_VERIFY OP_CHECKMULTISIGVERIFY".split()))
 
 INVALID_OPCODE_VALUES = frozenset((opcodes.OPCODE_TO_INT[s] for s in "OP_CAT OP_SUBSTR OP_LEFT OP_RIGHT OP_INVERT OP_AND OP_OR OP_XOR OP_2MUL OP_2DIV OP_MUL OP_DIV OP_MOD OP_LSHIFT OP_RSHIFT".split()))
@@ -174,10 +176,10 @@ def eval_script(script, signature_for_hash_type_f, expected_hash_type=None, stac
                 if v != VCH_TRUE:
                     raise ScriptError("VERIFY failed at %d" % pc-1)
 
-            logging.error("can't execute opcode %s", opcode)
+            logger.error("can't execute opcode %s", opcode)
 
     except Exception as ex:
-        logging.exception("script failed")
+        logger.exception("script failed")
 
     return len(stack) != 0
 
@@ -188,7 +190,7 @@ def verify_script(script_signature, script_public_key, signature_for_hash_type_f
                 and byte_to_int(script_public_key[-1]) == opcodes.OP_EQUAL)
 
     if not eval_script(script_signature, signature_for_hash_type_f, expected_hash_type, stack):
-        logging.debug("script_signature did not evaluate")
+        logger.debug("script_signature did not evaluate")
         return False
 
     if is_p2h:
@@ -196,7 +198,7 @@ def verify_script(script_signature, script_public_key, signature_for_hash_type_f
         alt_script_signature = bin_script(signatures)
 
     if not eval_script(script_public_key, signature_for_hash_type_f, expected_hash_type, stack):
-        logging.debug("script_public_key did not evaluate")
+        logger.debug("script_public_key did not evaluate")
         return False
 
     if is_p2h and stack[-1] == VCH_TRUE:

--- a/pycoin/wallet/SQLite3Persistence.py
+++ b/pycoin/wallet/SQLite3Persistence.py
@@ -1,11 +1,6 @@
-
-import io
-import logging
-import os
-
 from pycoin.serialize import b2h, h2b, b2h_rev, h2b_rev
 from pycoin.key.BIP32Node import BIP32Node
-from pycoin.tx import Spendable, Tx
+from pycoin.tx import Spendable
 
 class SQLite3Persistence(object):
     def __init__(self, sqlite3_db):
@@ -70,7 +65,7 @@ unique(path, key_id)
     def add_bip32_path(self, bip32_node, path):
         address = bip32_node.subkey_for_path(path).address()
         key_id = bip32_node.id
-        c = self._exec_sql("insert or ignore into BIP32Node values (?, ?, ?)", path, bip32_node.id, address)
+        c = self._exec_sql("insert or ignore into BIP32Node values (?, ?, ?)", path, key_id, address)
         self.db.commit()
         return address
 

--- a/test.sh
+++ b/test.sh
@@ -8,4 +8,4 @@ cd $THIS_DIR
 PYTHONPATH=$THIS_DIR
 export PYTHONPATH
 
-tox
+exec tox ${1+"${@}"}


### PR DESCRIPTION
...rather than the root logger. Other minor fixes.

*UPDATE: I'm pretty sure this is ready to merge, subject to review.*

This allows suppression of `pycoin` logging messages as follows:

```python
import logging
logging.getLogger('pycoin').addHandler(logging.NullHandler())
```

...or independent calls to `setLevel`, or [any number of means](https://docs.python.org/2/howto/logging.html). The point is that it plays nicely by staying in its own namespace.