### PR TITLE
READY FOR REVIEW - Alternate to PR #92 - Add `Tx.who_signed_me` convenience method to reveal which address(es) were...

### DIFF
--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -484,8 +484,8 @@ class Tx(object):
                 addr = script_obj_info.get('address')
                 _, sig_type = parse_signature_blob(h2b(tx_in_opcode_list[0]))
                 signed_by.append(( addr, sig_type ))
-        elif type(script_obj) in ( ScriptMultisig, ):
-            for opcode in tx_in_opcode_list:
+        elif type(script_obj) is ScriptMultisig:
+            for opcode in tx_in_opcode_list[1:]:
                 try:
                     sig_pair, sig_type = parse_signature_blob(h2b(opcode))
                 except ( TypeError, binascii.Error ):

--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -26,6 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import binascii
 import io
 
 from ..ecdsa import generator_secp256k1, verify as ecdsa_verify
@@ -487,7 +488,7 @@ class Tx(object):
             for opcode in tx_in_opcode_list:
                 try:
                     sig_pair, sig_type = parse_signature_blob(h2b(opcode))
-                except TypeError:
+                except ( TypeError, binascii.Error ):
                     continue
 
                 sig_hash = self.signature_hash(parent_tx_out_script, parent_tx_out_idx, sig_type)

--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -28,7 +28,9 @@ THE SOFTWARE.
 
 import io
 
-from ..encoding import double_sha256, from_bytes_32
+from ..ecdsa import generator_secp256k1, verify as ecdsa_verify
+from ..encoding import double_sha256, from_bytes_32, public_pair_to_bitcoin_address, sec_to_public_pair
+from ..networks import address_prefix_for_netcode
 from ..serialize import b2h, b2h_rev, h2b, h2b_rev
 from ..serialize.bitcoin_streamer import parse_struct, stream_struct
 from ..intbytes import byte_to_int
@@ -37,10 +39,11 @@ from .TxIn import TxIn
 from .TxOut import TxOut
 from .Spendable import Spendable
 
-from .pay_to import script_obj_from_script, SolvingError, ScriptPayToScript
+from .pay_to import script_obj_from_script, SolvingError, ScriptMultisig, ScriptPayToAddress, ScriptPayToPublicKey, ScriptPayToScript
 
 from .script import opcodes
 from .script import tools
+from .script.vm import parse_signature_blob
 
 
 SIGHASH_ALL = 1
@@ -54,6 +57,10 @@ class ValidationFailureError(Exception):
 
 
 class BadSpendableError(Exception):
+    pass
+
+
+class NoAddressesForScriptTypeError(Exception):
     pass
 
 
@@ -442,3 +449,43 @@ class Tx(object):
                 raise BadSpendableError("unspents[%d] script mismatch!" % idx)
 
         return self.fee()
+
+    def who_signed_me(self, tx_in_idx, netcode='BTC'):
+        tx_in = self.txs_in[tx_in_idx]
+        tx_in_opcode_list = tools.opcode_list(tx_in.script)
+        parent_tx_id = b2h_rev(tx_in.previous_hash)
+        parent_tx_out_idx = tx_in.previous_index
+        parent_tx_out_script = self.unspents[tx_in_idx].script
+        script_obj = script_obj_from_script(parent_tx_out_script)
+        signed_by = []
+
+        if script_obj is None:
+            script_obj_info = {}
+        else:
+            script_obj_info = script_obj.info(netcode=netcode)
+
+        if type(script_obj) in ( ScriptPayToAddress, ScriptPayToPublicKey ):
+            if self.is_signature_ok(tx_in_idx):
+                addr = script_obj_info.get('address')
+                _, sig_type = parse_signature_blob(h2b(tx_in_opcode_list[0]))
+                signed_by.append(( addr, sig_type ))
+        elif type(script_obj) in ( ScriptMultisig, ):
+            for opcode in tx_in_opcode_list:
+                try:
+                    sig_pair, sig_type = parse_signature_blob(h2b(opcode))
+                except TypeError:
+                    continue
+
+                sig_hash = self.signature_hash(parent_tx_out_script, parent_tx_out_idx, sig_type)
+
+                for sec_key in script_obj.sec_keys:
+                    public_pair = sec_to_public_pair(sec_key)
+
+                    if ecdsa_verify(generator_secp256k1, public_pair, sig_hash, sig_pair):
+                        addr_pfx = address_prefix_for_netcode(netcode)
+                        addr = public_pair_to_bitcoin_address(public_pair, address_prefix=addr_pfx)
+                        signed_by.append(( addr, sig_type ))
+        else:
+            raise NoAddressesForScriptTypeError('unable to determine signing addresses for script type of parent tx {}[{}]'.format(parent_tx_id, parent_tx_out_idx))
+
+        return signed_by

--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -451,6 +451,20 @@ class Tx(object):
         return self.fee()
 
     def who_signed_me(self, tx_in_idx, netcode='BTC'):
+        """
+        Given an input index (tx_in_idx), attempt to figure out which
+        addresses where used in signing (so far). This method depends on
+        self.unspents being properly configured. This should work on
+        partially-signed MULTISIG transactions (it will return as many
+        addresses as there are good signatures).
+
+        Returns a list of ( address, sig_type ) pairs.
+
+        Raises NoAddressesForScriptTypeError if addresses cannot be
+        determined for the input's script.
+
+        TODO: This does not yet support P2SH.
+        """
         tx_in = self.txs_in[tx_in_idx]
         tx_in_opcode_list = tools.opcode_list(tx_in.script)
         parent_tx_id = b2h_rev(tx_in.previous_hash)

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -136,8 +136,8 @@ class ScriptTypesTest(unittest.TestCase):
             hash160_lookup = build_hash160_lookup(key.secret_exponent() for key in keys[i-1:i])
             tx2.sign(hash160_lookup=hash160_lookup)
             self.assertEqual(tx2.id(), ids[i])
+            self.assertEqual(sorted(tx2.who_signed_me(0)), sorted(( ( key.address(), SIGHASH_ALL ) for key in keys[:i] )))
         self.assertEqual(tx2.bad_signature_count(), 0)
-        self.assertEqual(sorted(tx2.who_signed_me(0)), sorted(( ( key.address(), SIGHASH_ALL ) for key in keys[:N] )))
 
     def test_sign_pay_to_script_multisig(self):
         N, M = 3, 3

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -6,6 +6,7 @@ import unittest
 from pycoin.key import Key
 from pycoin.serialize import h2b
 from pycoin.tx import Tx, TxIn, TxOut, SIGHASH_ALL, tx_utils
+from pycoin.tx.Tx import NoAddressesForScriptTypeError
 from pycoin.tx.TxOut import standard_tx_out_script
 
 from pycoin.tx.pay_to import ScriptMultisig, ScriptPayToPublicKey
@@ -104,6 +105,7 @@ class ScriptTypesTest(unittest.TestCase):
         tx2.sign(hash160_lookup=hash160_lookup)
         self.assertEqual(tx2.id(), signed_id)
         self.assertEqual(tx2.bad_signature_count(), 0)
+        self.assertEqual(sorted(tx2.who_signed_me(0)), sorted(( ( key.address(), SIGHASH_ALL ) for key in keys[:N] )))
 
     def test_create_multisig_1_of_2(self):
         unsigned_id = "dd40f601e801ad87701b04851a4a6852d6b625e481d0fc9c3302faf613a4fc88"
@@ -135,6 +137,7 @@ class ScriptTypesTest(unittest.TestCase):
             tx2.sign(hash160_lookup=hash160_lookup)
             self.assertEqual(tx2.id(), ids[i])
         self.assertEqual(tx2.bad_signature_count(), 0)
+        self.assertEqual(sorted(tx2.who_signed_me(0)), sorted(( ( key.address(), SIGHASH_ALL ) for key in keys[:N] )))
 
     def test_sign_pay_to_script_multisig(self):
         N, M = 3, 3
@@ -151,6 +154,7 @@ class ScriptTypesTest(unittest.TestCase):
         p2sh_lookup = build_p2sh_lookup([underlying_script])
         tx2.sign(hash160_lookup=hash160_lookup, p2sh_lookup=p2sh_lookup)
         self.assertEqual(tx2.bad_signature_count(), 0)
+        self.assertRaises(NoAddressesForScriptTypeError, tx2.who_signed_me, 0)
 
     def test_weird_tx(self):
         # this is from tx 12a8d1d62d12307eac6e62f2f14d7e826604e53c320a154593845aa7c8e59fbf


### PR DESCRIPTION
...responsible for signing a particular transaction. This can be useful for seeing who signed an m-of-n multisig where m < n.

I'm not sure that adding a method to `Tx` is the right approach. It may be that `pycoin.tx.tx_utils` is a better place for this. Either way, I was unable to find an API or service out there that told me, for example, which two keys were used to sign a 2-of-3 `MULTISIG`, so I made this and felt like contributing. :smiley: