### PR TITLE
InsightService.send_tx error handling, missing imports

### DIFF
--- a/pycoin/services/insight.py
+++ b/pycoin/services/insight.py
@@ -22,8 +22,6 @@ from pycoin.serialize import b2h, b2h_rev, h2b, h2b_rev
 from pycoin.tx.script import tools
 from pycoin.tx import Spendable, Tx, TxIn, TxOut
 
-logger = logging.getLogger(__name__)
-
 
 class InsightService(object):
     def __init__(self, base_url):
@@ -96,7 +94,6 @@ class InsightService(object):
         return spendables
 
     def send_tx(self, tx):
-        # TODO: make this handle errors better
         s = io.BytesIO()
         tx.stream(s)
         tx_as_hex = b2h(s.getvalue())
@@ -105,9 +102,10 @@ class InsightService(object):
         try:
             d = urlopen(URL, data=data).read()
             return d
-        except HTTPError as ex:
-            logger.exception("problem in send_tx %s", tx.id())
-            raise ex
+        except HTTPError as err:
+            if err.code == 400:
+                raise ValueError(err.readline())
+            raise err
 
 
 def tx_from_json_dict(r):

--- a/pycoin/tx/pay_to/ScriptUnknown.py
+++ b/pycoin/tx/pay_to/ScriptUnknown.py
@@ -13,6 +13,7 @@ class ScriptUnknown(ScriptType):
         return self._script
 
     def solve(self, **kwargs):
+        from . import SolvingError
         raise SolvingError("unknown script type")
 
     def info(self, netcode='BTC'):


### PR DESCRIPTION
Minor/convenience fixes. Two scenarios:

1, Comprehensive exception instead of ugly HTTPError on InsightService.send_tx, such as:
<pre>ValueError: Transaction rejected by network (code -26). Reason: 64: non-canonical</pre>

2, Missing SolvingError import:
<pre>
>>> from pycoin.tx.pay_to import ScriptUnknown
>>> script = ScriptUnknown('abc')
>>> script.solve()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "build/bdist.linux-x86_64/egg/pycoin/tx/pay_to/ScriptUnknown.py", line 16, in solve
    raise SolvingError("unknown script type")
NameError: global name 'SolvingError' is not defined
</pre>

Thanks Richard for the awesome work