### PR TITLE
don't parse too many sigs in P2SH + OP_CHECKMULTISIG sig ordering + tests

### DIFF
--- a/pycoin/tx/pay_to/ScriptMultisig.py
+++ b/pycoin/tx/pay_to/ScriptMultisig.py
@@ -93,11 +93,13 @@ class ScriptMultisig(ScriptType):
         existing_script = kwargs.get("existing_script")
         if existing_script:
             pc = 0
+            seen = 0
             opcode, data, pc = tools.get_opcode(existing_script, pc)
             # ignore the first opcode
-            while pc < len(existing_script):
+            while pc < len(existing_script) and seen < self.n:
                 opcode, data, pc = tools.get_opcode(existing_script, pc)
                 sig_pair, actual_signature_type = parse_signature_blob(data)
+                seen += 1
                 for sec_key in self.sec_keys:
                     try:
                         public_pair = encoding.sec_to_public_pair(sec_key)

--- a/pycoin/tx/pay_to/ScriptMultisig.py
+++ b/pycoin/tx/pay_to/ScriptMultisig.py
@@ -113,7 +113,7 @@ class ScriptMultisig(ScriptType):
                         # if public_pair is invalid, we just ignore it
                         pass
 
-        for sec_key in self.sec_keys:
+        for signature_order, sec_key in enumerate(self.sec_keys):
             if sec_key in secs_solved:
                 continue
             if len(existing_signatures) >= self.n:
@@ -124,7 +124,7 @@ class ScriptMultisig(ScriptType):
                 continue
             secret_exponent, public_pair, compressed = result
             binary_signature = self._create_script_signature(secret_exponent, sign_value, signature_type)
-            existing_signatures.append(binary_signature)
+            existing_signatures.insert(signature_order, binary_signature)
 
         if dummy_fill:
             DUMMY_SIGNATURE = self._dummy_signature(signature_type)

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import io
+import copy
 import unittest
 from pycoin.key import Key
 from pycoin.serialize import h2b
@@ -145,11 +146,14 @@ class ScriptTypesTest(unittest.TestCase):
         spendable = {'script_hex': 'a914c4ed4de526461e3efbb79c8b688a6f9282c0464687', 'does_seem_spent': 0,
                      'block_index_spent': 0, 'tx_hash_hex': '0ca152ba6b88db87a7ef1afd24554102aca1ab86cf2c10ccbc374472145dc943',
                      'coin_value': 10000, 'block_index_available': 0, 'tx_out_index': 0}
-        tx = Tx(version=DEFAULT_VERSION, txs_in=txs_in, txs_out=txs_out, unspents=[Spendable.from_dict(spendable)])
-        for key in ['Kz6pytJCigYHeMsGLmfHQPJhN5og2wpeSVrU43xWwgHLCAvpsprh', 'Kz7NHgX7MBySA3RSKj9GexUSN6NepEDoPNugSPr5absRDoKgn2dT']:
-            self.assertEqual(tx.bad_signature_count(), 1)
-            tx.sign(LazySecretExponentDB([key], {}), p2sh_lookup=build_p2sh_lookup(raw_scripts))
-        self.assertEqual(tx.bad_signature_count(), 0)
+        tx__prototype = Tx(version=DEFAULT_VERSION, txs_in=txs_in, txs_out=txs_out, unspents=[Spendable.from_dict(spendable)])
+        key_1, key_2 = 'Kz6pytJCigYHeMsGLmfHQPJhN5og2wpeSVrU43xWwgHLCAvpsprh', 'Kz7NHgX7MBySA3RSKj9GexUSN6NepEDoPNugSPr5absRDoKgn2dT'
+        for ordered_keys in [(key_1, key_2), (key_2, key_1)]:
+            tx = copy.deepcopy(tx__prototype)
+            for key in ordered_keys:
+                self.assertEqual(tx.bad_signature_count(), 1)
+                tx.sign(LazySecretExponentDB([key], {}), p2sh_lookup=build_p2sh_lookup(raw_scripts))
+            self.assertEqual(tx.bad_signature_count(), 0)
 
     def test_sign_pay_to_script_multisig(self):
         N, M = 3, 3

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -2,15 +2,17 @@
 
 import io
 import unittest
-
 from pycoin.key import Key
 from pycoin.serialize import h2b
+from pycoin.scripts.tx import DEFAULT_VERSION
 from pycoin.tx import Tx, TxIn, TxOut, SIGHASH_ALL, tx_utils
 from pycoin.tx.TxOut import standard_tx_out_script
-
+from pycoin.tx.Spendable import Spendable
+from pycoin.tx.tx_utils import LazySecretExponentDB
 from pycoin.tx.pay_to import ScriptMultisig, ScriptPayToPublicKey, ScriptNulldata
 from pycoin.tx.pay_to import address_for_pay_to_script, build_hash160_lookup, build_p2sh_lookup
 from pycoin.tx.pay_to import script_obj_from_address, script_obj_from_script
+
 
 class ScriptTypesTest(unittest.TestCase):
 
@@ -135,6 +137,19 @@ class ScriptTypesTest(unittest.TestCase):
             tx2.sign(hash160_lookup=hash160_lookup)
             self.assertEqual(tx2.id(), ids[i])
         self.assertEqual(tx2.bad_signature_count(), 0)
+
+    def test_p2sh_multisig_sequential_signing(self):
+        raw_scripts = ['52210234abcffd2e80ad01c2ec0276ad02682808169c6fafdd25ebfb60703df272b4612102e5baaafff8094e4d77ce8b009d5ebc3de9110085ebd3d96e50cc7ce70faf1752210316ee25e80eb6e6fc734d9c86fa580cbb9c4bfd94a19f0373a22353ececd4db6853ae'.decode('hex')]
+        txs_in = [TxIn(previous_hash='43c95d14724437bccc102ccf86aba1ac02415524fd1aefa787db886bba52a10c'.decode('hex'), previous_index=0)]
+        txs_out = [TxOut(10000, standard_tx_out_script('3KeGeLFmsbmbVdeMLrWp7WYKcA3tdsB4AR'))]
+        spendable = {'script_hex': 'a914c4ed4de526461e3efbb79c8b688a6f9282c0464687', 'does_seem_spent': 0,
+                     'block_index_spent': 0, 'tx_hash_hex': '0ca152ba6b88db87a7ef1afd24554102aca1ab86cf2c10ccbc374472145dc943',
+                     'coin_value': 10000, 'block_index_available': 0, 'tx_out_index': 0}
+        tx = Tx(version=DEFAULT_VERSION, txs_in=txs_in, txs_out=txs_out, unspents=[Spendable.from_dict(spendable)])
+        for key in ['Kz6pytJCigYHeMsGLmfHQPJhN5og2wpeSVrU43xWwgHLCAvpsprh', 'Kz7NHgX7MBySA3RSKj9GexUSN6NepEDoPNugSPr5absRDoKgn2dT']:
+            self.assertEqual(tx.bad_signature_count(), 1)
+            tx.sign(LazySecretExponentDB([key], {}), p2sh_lookup=build_p2sh_lookup(raw_scripts))
+        self.assertEqual(tx.bad_signature_count(), 0)
 
     def test_sign_pay_to_script_multisig(self):
         N, M = 3, 3

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -139,8 +139,8 @@ class ScriptTypesTest(unittest.TestCase):
         self.assertEqual(tx2.bad_signature_count(), 0)
 
     def test_p2sh_multisig_sequential_signing(self):
-        raw_scripts = ['52210234abcffd2e80ad01c2ec0276ad02682808169c6fafdd25ebfb60703df272b4612102e5baaafff8094e4d77ce8b009d5ebc3de9110085ebd3d96e50cc7ce70faf1752210316ee25e80eb6e6fc734d9c86fa580cbb9c4bfd94a19f0373a22353ececd4db6853ae'.decode('hex')]
-        txs_in = [TxIn(previous_hash='43c95d14724437bccc102ccf86aba1ac02415524fd1aefa787db886bba52a10c'.decode('hex'), previous_index=0)]
+        raw_scripts = [h2b('52210234abcffd2e80ad01c2ec0276ad02682808169c6fafdd25ebfb60703df272b4612102e5baaafff8094e4d77ce8b009d5ebc3de9110085ebd3d96e50cc7ce70faf1752210316ee25e80eb6e6fc734d9c86fa580cbb9c4bfd94a19f0373a22353ececd4db6853ae')]
+        txs_in = [TxIn(previous_hash=h2b('43c95d14724437bccc102ccf86aba1ac02415524fd1aefa787db886bba52a10c'), previous_index=0)]
         txs_out = [TxOut(10000, standard_tx_out_script('3KeGeLFmsbmbVdeMLrWp7WYKcA3tdsB4AR'))]
         spendable = {'script_hex': 'a914c4ed4de526461e3efbb79c8b688a6f9282c0464687', 'does_seem_spent': 0,
                      'block_index_spent': 0, 'tx_hash_hex': '0ca152ba6b88db87a7ef1afd24554102aca1ab86cf2c10ccbc374472145dc943',


### PR DESCRIPTION
Credits @devrandom
Adding a test case

The test will get current HEAD confused on a redeem script:
```
    def remove_sequence(string):
        if not string.startswith(b"\x30"):
            raise UnexpectedDER(
                "wanted sequence (0x30), got string length %d %s" % (
>                   len(string), binascii.hexlify(string[:10])))
E           UnexpectedDER: wanted sequence (0x30), got string length 104 52210234abcffd2e80ad

pycoin/tx/script/der.py:62: UnexpectedDER
```