### PR TITLE
READY: eval_script op_checkmultisig to not log an exception on dummy signatures

### DIFF
--- a/pycoin/ecdsa/__init__.py
+++ b/pycoin/ecdsa/__init__.py
@@ -1,6 +1,6 @@
 
 from .ecdsa import is_public_pair_valid, public_pair_for_secret_exponent, public_pair_for_x, possible_public_pairs_for_signature, sign, verify
 
-from .ellipticcurve import CurveFp, Point
+from .ellipticcurve import CurveFp, Point, NoSuchPointError
 
 from .secp256k1 import generator_secp256k1

--- a/pycoin/tx/pay_to/ScriptType.py
+++ b/pycoin/tx/pay_to/ScriptType.py
@@ -74,7 +74,8 @@ class ScriptType(object):
             s = order - s
         return der.sigencode_der(r, s) + bytes_from_int(signature_type)
 
-    def _dummy_signature(self, signature_type):
+    @staticmethod
+    def _dummy_signature(signature_type):
         order = ecdsa.generator_secp256k1.order()
         r, s = order - 1, order // 2
         return der.sigencode_der(r, s) + bytes_from_int(signature_type)

--- a/pycoin/tx/script/check_signature.py
+++ b/pycoin/tx/script/check_signature.py
@@ -97,8 +97,14 @@ def sig_blob_matches(sig_blobs, public_pairs, tmp_script, signature_for_hash_typ
         if signature_type not in sig_cache:
             sig_cache[signature_type] = signature_for_hash_type_f(signature_type, script=tmp_script)
 
-        ppp = ecdsa.possible_public_pairs_for_signature(
-            ecdsa.generator_secp256k1, sig_cache[signature_type], sig_pair)
+        try:
+            ppp = ecdsa.possible_public_pairs_for_signature(
+                ecdsa.generator_secp256k1, sig_cache[signature_type], sig_pair)
+        except ecdsa.NoSuchPointError as err:
+            from ..pay_to.ScriptType import ScriptType  # to avoid cyclical imports
+            if sig_blob != ScriptType._dummy_signature(signature_type):
+                raise  # out of curve signature that is not dummy_signature
+            ppp = []
 
         if len(ppp) > 0:
             for idx, pp in enumerate(public_pairs):

--- a/pycoin/tx/script/check_signature.py
+++ b/pycoin/tx/script/check_signature.py
@@ -101,9 +101,6 @@ def sig_blob_matches(sig_blobs, public_pairs, tmp_script, signature_for_hash_typ
             ppp = ecdsa.possible_public_pairs_for_signature(
                 ecdsa.generator_secp256k1, sig_cache[signature_type], sig_pair)
         except ecdsa.NoSuchPointError as err:
-            from ..pay_to.ScriptType import ScriptType  # to avoid cyclical imports
-            if sig_blob != ScriptType._dummy_signature(signature_type):
-                raise  # out of curve signature that is not dummy_signature
             ppp = []
 
         if len(ppp) > 0:


### PR DESCRIPTION
When signing txs with op_checkmultisig in them, this would show up in the console:
`No handlers could be found for logger "pycoin.tx.script.vm"`

It confused me a lot when I was getting familiar with pycoin. Turns out it can't place a dummy signature on the curve:
```
ERROR:pycoin.tx.script.vm:script failed
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/pycoin/tx/script/vm.py", line 126, in eval_script
    stack, signature_for_hash_type_f, expected_hash_type, script[begin_code_hash:])
  File "build/bdist.linux-x86_64/egg/pycoin/tx/script/check_signature.py", line 152, in op_checkmultisig
    sig_blobs, public_pairs, tmp_script, signature_for_hash_type_f, strict_checks=True)
  File "build/bdist.linux-x86_64/egg/pycoin/tx/script/check_signature.py", line 101, in sig_blob_matches
    ecdsa.generator_secp256k1, sig_cache[signature_type], sig_pair)
  File "build/bdist.linux-x86_64/egg/pycoin/ecdsa/ecdsa.py", line 168, in possible_public_pairs_for_signature
    R = ellipticcurve.Point(curve, x, y, order)
  File "build/bdist.linux-x86_64/egg/pycoin/ecdsa/ellipticcurve.py", line 79, in __init__
    raise NoSuchPointError('({},{}) is not on the curve {}'.format(x, y, curve))
NoSuchPointError: (115792089237316195423570985008687907852837564279074904382605163141518161494336,0) is not on the curve y^2 = x^3 + 0*x + 7 (mod 115792089237316195423570985008687907853269984665640564039457584007908834671663)
```

The fix: evaluate dummy signatures as invalid but don't throw errors.