### PR TITLE
Changed Darkcoin to DASH, network from DRK to DASH

### DIFF
--- a/pycoin/networks.py
+++ b/pycoin/networks.py
@@ -41,13 +41,13 @@ NETWORKS = (
     # BC BlackCoin mainnet : bcpv/bcpb
     NetworkValues("Blackcoin", "mainnet", "BC", b'\x99', b'\x19', None, h2b("02cfbf60"), h2b("02cfbede")),
 
-    # DRK Darkcoin mainnet : drkv/drkp
+    # DRK Dash mainnet : drkv/drkp
     NetworkValues(
-        "Darkcoin", "mainnet", "DRK", b'\xcc', b'\x4c', b'\x10', h2b("02fe52f8"), h2b("02fe52cc")),
+        "Dash", "mainnet", "DASH", b'\xcc', b'\x4c', b'\x10', h2b("02fe52f8"), h2b("02fe52cc")),
 
-    # DRK Darkcoin testnet : DRKV/DRKP
+    # DRK Dash testnet : DRKV/DRKP
     NetworkValues(
-        "Darkcoin", "testnet", "tDRK", b'\xef', b'\x8b', b'\x13', h2b("3a8061a0"), h2b("3a805837")),
+        "Dash", "testnet", "tDASH", b'\xef', b'\x8b', b'\x13', h2b("3a8061a0"), h2b("3a805837")),
 
     # MEC Megacoin mainnet : mecv/mecp
     NetworkValues("Megacoin", "mainnet", "MEC", b'\xb2', b'\x32', None, h2b("03a04db7"), h2b("03a04d8b")),


### PR DESCRIPTION
simple update to pycoin labels (display,network-type) to follow darkcoins rebrand to dash.
bip32 magic numbers left unchanged for backward compatibility
