### PR TITLE
Compatibility with Appengine and some other environments

### DIFF
--- a/pycoin/ecdsa/ellipticcurve.py
+++ b/pycoin/ecdsa/ellipticcurve.py
@@ -34,7 +34,12 @@
 
 from . import numbertheory
 
-from .native.library import NATIVE_LIBRARY
+
+try:
+    from .native.library import NATIVE_LIBRARY
+except ImportError:
+    NATIVE_LIBRARY = None
+
 
 
 class NoSuchPointError(ValueError): pass

--- a/pycoin/ecdsa/native/library.py
+++ b/pycoin/ecdsa/native/library.py
@@ -89,8 +89,11 @@ def make_inverse_mod_f(library):
         return a1.to_int()
     return inverse_mod
 
+try:
+    NATIVE_LIBRARY = load_library()
+except:
+    NATIVE_LIBRARY = None
 
-NATIVE_LIBRARY = load_library()
 if NATIVE_LIBRARY:
     NATIVE_LIBRARY.fast_mul = make_fast_mul_f(NATIVE_LIBRARY)
     NATIVE_LIBRARY.inverse_mod = make_inverse_mod_f(NATIVE_LIBRARY)

--- a/pycoin/ecdsa/numbertheory.py
+++ b/pycoin/ecdsa/numbertheory.py
@@ -1,5 +1,7 @@
-from .native.library import NATIVE_LIBRARY
-
+try:
+    from .native.library import NATIVE_LIBRARY
+except ImportError:
+    NATIVE_LIBRARY = None
 
 def inverse_mod( a, m ):
   """Inverse of a mod m."""


### PR DESCRIPTION
Most cloud environment (such as Appengine) does not support C modules (ctypes) in Python environment (reference: [Appengine documentation](https://cloud.google.com/appengine/kb/libraries)).
This commit https://github.com/richardkiss/pycoin/commit/43952daee3ec6e7077e4cef435bf0bcd05cd2096 made pycoin unusable in such environments. This PR solves the compatibility issue