### PR TITLE
Fixed get_opcode for sizes larger than 1 byte

### DIFF
--- a/pycoin/intbytes.py
+++ b/pycoin/intbytes.py
@@ -35,7 +35,7 @@ bytes_from_ints = (lambda l: b''.join(chr(x) for x in l)) if bytes == str else b
 if hasattr(int, "to_bytes"):
     to_bytes = lambda v, length, byteorder="big": v.to_bytes(length, byteorder=byteorder)
     from_bytes = lambda bytes, byteorder="big", signed=False: int.from_bytes(
-        bytes, byteorder="big", signed=signed)
+        bytes, byteorder=byteorder, signed=signed)
     int_to_bytes = lambda v: v.to_bytes((v.bit_length()+7)//8, byteorder="big")
     int_from_bytes = lambda v: int.from_bytes(v, byteorder="big")
 else:

--- a/pycoin/tx/script/tools.py
+++ b/pycoin/tx/script/tools.py
@@ -32,7 +32,7 @@ import logging
 import struct
 
 from .opcodes import OPCODE_TO_INT, INT_TO_OPCODE
-from ...intbytes import bytes_from_int, bytes_to_ints, int_to_bytes, int_from_bytes
+from ...intbytes import bytes_from_int, bytes_to_ints, to_bytes, from_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +46,13 @@ def get_opcode(script, pc):
         if opcode < OPCODE_TO_INT["OP_PUSHDATA1"]:
             size = opcode
         elif opcode == OPCODE_TO_INT["OP_PUSHDATA1"]:
-            size = int_from_bytes(script[pc:pc+1])
+            size = from_bytes(script[pc:pc+1], byteorder="little")
             pc += 1
         elif opcode == OPCODE_TO_INT["OP_PUSHDATA2"]:
-            size = int_from_bytes(script[pc:pc+2])
+            size = from_bytes(script[pc:pc+2], byteorder="little")
             pc += 2
         elif opcode == OPCODE_TO_INT["OP_PUSHDATA4"]:
-            size = int_from_bytes(script[pc:pc+4])
+            size = from_bytes(script[pc:pc+4], byteorder="little")
             pc += 4
         data = script[pc:pc+size]
         pc += size
@@ -69,16 +69,16 @@ def write_push_data(data_list, f):
         if len(t) <= 255:
             if len(t) > 75:
                 f.write(bytes_from_int(OPCODE_TO_INT["OP_PUSHDATA1"]))
-            f.write(int_to_bytes(len(t)))
+            f.write(to_bytes(len(t), 1, 'little'))
             f.write(t)
         elif len(t) <= 65535:
             f.write(bytes_from_int(OPCODE_TO_INT["OP_PUSHDATA2"]))
-            f.write(struct.pack(">H", len(t)))
+            f.write(struct.pack("<H", len(t)))
             f.write(t)
         else:
             # This will never be used in practice as it makes the scripts too long.
             f.write(bytes_from_int(OPCODE_TO_INT["OP_PUSHDATA4"]))
-            f.write(struct.pack(">L", len(t)))
+            f.write(struct.pack("<L", len(t)))
             f.write(t)
 
 def bin_script(data_list):

--- a/tests/validate_tx_test.py
+++ b/tests/validate_tx_test.py
@@ -183,10 +183,10 @@ W4iswJ7mBQAAAAAZdqkU4E5+Is4tr+8bPU6ELYHSvz/Ng0eIrAAAAAA=
         self.assertEqual(tx_to_validate.bad_signature_count(), 0)
 
     def test_endian(self):
-        from pycoin.tx.script.tools import int_from_bytes, int_to_bytes
-        assert int_from_bytes(int_to_bytes(768)) == 768
-        assert int_from_bytes(int_to_bytes(3)) == 3
-        assert int_from_bytes(int_to_bytes(66051)) == 66051
+        from pycoin.tx.script.tools import from_bytes, to_bytes
+        assert from_bytes(to_bytes(768, 2, 'little'), 'little') == 768
+        assert from_bytes(to_bytes(3, 1, 'little'), 'little') == 3
+        assert from_bytes(to_bytes(66051, 3, 'little'), 'little') == 66051
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In 0.42 get_opcode in Python 2 correctly used little endian integers parsing (https://github.com/richardkiss/pycoin/blob/0.42/pycoin/tx/script/tools.py#L52), but in 0.60 it now uses big endian. This causes larger sizes to be parsed incorrectly.

For Python 3.2+, the bug was always there.