### PR TITLE
Added DEFCOIN (DFC) support to networks.py

### DIFF
--- a/pycoin/networks.py
+++ b/pycoin/networks.py
@@ -67,6 +67,10 @@ NETWORKS = (
     NetworkValues(
         "Riecoin", "mainnet", "RIC", b'\x80', b'\x3c', b'\x05', h2b('0488ADE4'), h2b('0488B21E')),
 
+    # DFC Defcoin mainnet: dfcv/dfcp
+    NetworkValues(
+        "DEFCOIN", "mainnet", "DFC", b'\x9e', b'\x1e', b'\x16', h2b("02FA54D7"), h2b("02FA54AD")),
+
 )
 
 


### PR DESCRIPTION
I've added DFC to the networks.py file to add support for the DEFCOIN cryptocurrency.

Although it's not valuable, DEFCOINs are used at the world's largest hacker conference - DEFCON - in Las Vegas every year. This simple patch adds support for it.