### PR TITLE
sign_tx_in should pass hash_type

### DIFF
--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -281,7 +281,7 @@ class Tx(object):
 
     def sign_tx_in(self, hash160_lookup, tx_in_idx, tx_out_script, hash_type=SIGHASH_ALL, **kwargs):
         self.txs_in[tx_in_idx].script = self.solve(hash160_lookup, tx_in_idx, tx_out_script,
-                                                   hash_type=SIGHASH_ALL, **kwargs)
+                                                   hash_type=hash_type, **kwargs)
 
     def verify_tx_in(self, tx_in_idx, tx_out_script, expected_hash_type=None):
         tx_in = self.txs_in[tx_in_idx]


### PR DESCRIPTION
sign_tx_in should pass the given hash_type instead of default to SIGHASH_ALL