### PR TITLE
Nulldata refresh - Addresses #203

### DIFF
--- a/pycoin/tx/pay_to/ScriptType.py
+++ b/pycoin/tx/pay_to/ScriptType.py
@@ -69,8 +69,6 @@ class ScriptType(object):
                     break
                 r["PUBKEYHASH_LIST"].append(data1)
             elif opcode2 == opcodes.OP_NULLDATA:
-                if not (0 < l1 <= 40):
-                    break
                 r["NULLDATA_LIST"].append(data1)
             elif (opcode1, data1) != (opcode2, data2):
                 break

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -178,7 +178,7 @@ class ScriptTypesTest(unittest.TestCase):
 
     def test_nulldata(self):
         # note that because chr() is used samples with length > 255 will not work
-        for sample in [b'test', b'me', b'a', b'39qEwuwyb2cAX38MFtrNzvq3KV9hSNov3q', b'']:
+        for sample in [b'test', b'me', b'a', b'39qEwuwyb2cAX38MFtrNzvq3KV9hSNov3q', b'', b'0'*80]:
             sample_script = b'\x6a' + chr(len(sample)).encode() + sample
             nd = ScriptNulldata(sample)
             self.assertEqual(nd.nulldata, sample)

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -179,7 +179,11 @@ class ScriptTypesTest(unittest.TestCase):
     def test_nulldata(self):
         # note that because chr() is used samples with length > 255 will not work
         for sample in [b'test', b'me', b'a', b'39qEwuwyb2cAX38MFtrNzvq3KV9hSNov3q', b'', b'0'*80]:
-            sample_script = b'\x6a' + chr(len(sample)).encode() + sample
+            if len(sample) <= 75:
+                pushdata = b''
+            else:  # not testing payloads above 65k chars...
+                pushdata = b'\x4c'
+            sample_script = b'\x6a' + pushdata + chr(len(sample)).encode() + sample
             nd = ScriptNulldata(sample)
             self.assertEqual(nd.nulldata, sample)
             self.assertEqual(nd.script(), sample_script)

--- a/tests/pay_to_test.py
+++ b/tests/pay_to_test.py
@@ -178,7 +178,7 @@ class ScriptTypesTest(unittest.TestCase):
 
     def test_nulldata(self):
         # note that because chr() is used samples with length > 255 will not work
-        for sample in [b'test', b'me', b'a', b'39qEwuwyb2cAX38MFtrNzvq3KV9hSNov3q']:
+        for sample in [b'test', b'me', b'a', b'39qEwuwyb2cAX38MFtrNzvq3KV9hSNov3q', b'']:
             sample_script = b'\x6a' + chr(len(sample)).encode() + sample
             nd = ScriptNulldata(sample)
             self.assertEqual(nd.nulldata, sample)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, pypy
+envlist = py27, py33, py34, py35, pypy
 
 [testenv]
 commands = py.test tests


### PR DESCRIPTION
- First commit will show that an empty nulldata tx fails the tests
- Second commit will add an 80 byte test and remove length check

This PR addresses #203 

Edit:
### Summary of Changes
- Remove length check (IE if it compiles, it's valid nulldata even if not a standard transaction)
- Add py35 as a testing environment (can remove or separate into a new PR if you like)
- Add two nulldata tests:
  - Add an empty nulldata (script: `6a00`)
  - Add an 80 byte nulldata (which is standard in bitcoin-core atm)
