### PR TITLE
Handle py3 case of bytes (not string) being provided as signature

### DIFF
--- a/pycoin/contrib/msg_signing.py
+++ b/pycoin/contrib/msg_signing.py
@@ -214,7 +214,7 @@ def _decode_signature(signature):
         Decode the internal fields of the base64-encoded signature.
     """
 
-    if signature[0] not in ('G', 'H', 'I'):
+    if signature[0] not in ('G','H','I', 71,72,73):
         # Because we know the first char is in range(27, 35), we know
         # valid first character is in this set.
         raise TypeError("Expected base64 value as signature", signature)

--- a/tests/msg_signing_test.py
+++ b/tests/msg_signing_test.py
@@ -49,6 +49,8 @@ def test_against_myself():
             ok = verify_message(k, sig2, msg)
             assert ok
 
+            ok = verify_message(k, bytes(sig2, 'utf-8'), msg)
+            assert ok
 
 def test_msg_parse():
     """

--- a/tests/msg_signing_test.py
+++ b/tests/msg_signing_test.py
@@ -49,7 +49,7 @@ def test_against_myself():
             ok = verify_message(k, sig2, msg)
             assert ok
 
-            ok = verify_message(k, bytes(sig2, 'utf-8'), msg)
+            ok = verify_message(k, sig2.encode('ascii'), msg)
             assert ok
 
 def test_msg_parse():


### PR DESCRIPTION
- also provides a test case 