### PR TITLE
fix tx.py line 517

### DIFF
--- a/pycoin/cmds/tx.py
+++ b/pycoin/cmds/tx.py
@@ -518,7 +518,7 @@ def parse_context(args, parser):
     if args.fetch_spendables:
         warning_spendables = message_about_spendables_for_address_env(args.network)
         for address in args.fetch_spendables:
-            spendables.extend(spendables_for_address(address))
+            spendables.extend(spendables_for_address(address, args.network))
 
     return (txs, spendables, payables, key_iters, tx_db, warning_spendables)
 


### PR DESCRIPTION
Currently, tx command described in https://github.com/richardkiss/pycoin/blob/master/COMMAND-LINE-TOOLS.md shows error when try out this line.

I just fixed it.
```
$ tx -F 85000 -i 12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX 1KissFDVu2wAYWPRm4UGh5ZCDU9sE9an8T 1KissEskteXTAXbh17qJYLtMes1B6kJxZj 12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX/50
Traceback (most recent call last):
  File "/Users/shunusami/.anyenv/envs/pyenv/versions/3.5.2/bin/tx", line 9, in <module>
    load_entry_point('pycoin==0.77', 'console_scripts', 'tx')()
  File "/Users/shunusami/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pycoin/cmds/tx.py", line 475, in main
    warning_tx_cache, warning_tx_for_tx_hash, warning_spendables) = parse_context(args, parser)
  File "/Users/shunusami/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pycoin/cmds/tx.py", line 456, in parse_context
    spendables.extend(spendables_for_address(address))
TypeError: spendables_for_address() missing 1 required positional argument: 'netcode'
```