### PR TITLE
Fix for blocks that contain witness transactions.

### DIFF
--- a/pycoin/block.py
+++ b/pycoin/block.py
@@ -141,7 +141,7 @@ class Block(object):
     def check_merkle_hash(self):
         """Raise a BadMerkleRootError if the Merkle hash of the
         transactions does not match the Merkle hash included in the block."""
-        calculated_hash = merkle([tx.hash() for tx in self.txs], double_sha256)
+        calculated_hash = merkle([tx.txid() for tx in self.txs], double_sha256)
         if calculated_hash != self.merkle_root:
             raise BadMerkleRootError(
                 "calculated %s but block contains %s" % (b2h(calculated_hash), b2h(self.merkle_root)))

--- a/pycoin/tx/Tx.py
+++ b/pycoin/tx/Tx.py
@@ -200,6 +200,11 @@ class Tx(object):
     def has_witness_data(self):
         return any(len(tx_in.witness) > 0 for tx_in in self.txs_in)
 
+    def txid(self):
+        if not self.has_witness_data():
+            return self.hash()
+        return double_sha256(self.as_bin(include_witness_data=False))
+
     def hash(self, hash_type=None):
         """Return the hash for this Tx object."""
         s = io.BytesIO()
@@ -445,11 +450,13 @@ class Tx(object):
         return len(self.txs_in) == 1 and self.txs_in[0].is_coinbase()
 
     def __str__(self):
-        return "Tx [%s]" % self.id()
+        type_str = 'WTx' if self.has_witness_data() else 'Tx'
+        return "%s [%s]" % (type_str, self.txid())
 
     def __repr__(self):
-        return "Tx [%s] (v:%d) [%s] [%s]" % (
-            self.id(), self.version, ", ".join(str(t) for t in self.txs_in),
+        type_str = 'WTx' if self.has_witness_data() else 'Tx'
+        return "%s [%s] (v:%d) [%s] [%s]" % (
+            type_str, self.txid(), self.version, ", ".join(str(t) for t in self.txs_in),
             ", ".join(str(t) for t in self.txs_out))
 
     def _check_tx_inout_count(self):


### PR DESCRIPTION
A transaction's `hash` != `txid` when witness data is present. Thus check_merkle_hash fails.
Also changes display to `Tx [tx.hash()]` to `WTx [tx.txid]` for `str()` and `repr()` for transactions that have witness data present.