### PR TITLE
Added dash to Blockcypher provider

### DIFF
--- a/pycoin/ecdsa/native/openssl.py
+++ b/pycoin/ecdsa/native/openssl.py
@@ -38,7 +38,6 @@ def load_library():
     BN_CTX = ctypes.POINTER(BignumContext)
 
     BIGNUM_API = [
-        ("BN_init", [BN_P], None),
         ("BN_new", [], BN_P),
         ("BN_set_word", [BN_P, ctypes.c_ulong], ctypes.c_int),
         ("BN_clear_free", [BN_P], None),

--- a/pycoin/services/blockcypher.py
+++ b/pycoin/services/blockcypher.py
@@ -11,8 +11,9 @@ from pycoin.tx.Tx import Spendable, Tx
 class BlockcypherProvider(object):
     def __init__(self, api_key="", netcode=None):
         NETWORK_PATHS = {
-            "BTC": "main",
-            "XTN": "test3"
+            "BTC": "btc/main",
+            "XTN": "btc/test3",
+            "DASH": "dash/main",
         }
 
         if netcode is None:
@@ -21,8 +22,10 @@ class BlockcypherProvider(object):
         self.network_path = NETWORK_PATHS.get(netcode)
         self.api_key = api_key
 
+        print(netcode)
+
     def base_url(self, args):
-        return "https://api.blockcypher.com/v1/btc/%s/%s" % (self.network_path, args)
+        return "https://api.blockcypher.com/v1/%s/%s" % (self.network_path, args)
 
     def spendables_for_address(self, address):
         """
@@ -69,5 +72,5 @@ class BlockcypherProvider(object):
         """
         url = self.base_url("txs/push")
         data = {"tx": tx.as_hex()}
-        result = json.loads(urlopen(url, data=json.dumps(data)).read().decode("utf8"))
+        result = json.loads(urlopen(url, data=json.dumps(data).encode('utf8')).read().decode("utf8"))
         return result


### PR DESCRIPTION
I also had to remove a reference to the openssl function BN_init because it's deprecated and not present in libcrypto.so.1.1.

I'm actually slightly surprised that the fix I made in broadcast_tx hasn't caused issued for anyone using this for btc.