### PR TITLE
Add the ability to read input data from stdin

### DIFF
--- a/pycoin/cmds/ku.py
+++ b/pycoin/cmds/ku.py
@@ -329,7 +329,6 @@ def ku(args, parser):
     PREFIX_TRANSFORMS = prefix_transforms_for_network(args.network)
 
     def parse_stdin():
-        import sys
         return [item for item in sys.stdin.readline().strip().split(' ') if len(item) > 0]
 
     items = args.item if len(args.item) > 0 else parse_stdin()

--- a/pycoin/cmds/ku.py
+++ b/pycoin/cmds/ku.py
@@ -234,7 +234,7 @@ def create_parser():
                         default=None, choices=codes)
 
     parser.add_argument(
-        'item', nargs="+", help='a BIP0032 wallet key string;'
+        'item', nargs="*", help='a BIP0032 wallet key string;'
         ' a WIF;'
         ' a bitcoin address;'
         ' an SEC (ie. a 66 hex chars starting with 02, 03 or a 130 hex chars starting with 04);'
@@ -244,7 +244,8 @@ def create_parser():
         ' E:electrum value (either a master public, master private, or initial data);'
         ' secret_exponent (in decimal or hex);'
         ' x,y where x,y form a public pair (y is a number or one of the strings "even" or "odd");'
-        ' hash160 (as 40 hex characters)')
+        ' hash160 (as 40 hex characters).'
+        ' If this argument is missing, input data will be read from stdin.')
     return parser
 
 
@@ -327,7 +328,13 @@ def ku(args, parser):
 
     PREFIX_TRANSFORMS = prefix_transforms_for_network(args.network)
 
-    for item in args.item:
+    def parse_stdin():
+        import sys
+        return [item for item in sys.stdin.readline().strip().split(' ') if len(item) > 0]
+
+    items = args.item if len(args.item) > 0 else parse_stdin()
+
+    for item in items:
         key = parse_key(item, PREFIX_TRANSFORMS, args.network)
 
         if key is None:


### PR DESCRIPTION
The "ku" tool currently lacks the ability to read keys from the standard input (which also makes piping impossible). Oftentimes a private key will be supplied from another tool, in which case the ability to pipe data in is necessary.

This commit makes it possible to take data in from stdin when no positional arguments are present.

