### PR TITLE
Add Groestlcoin

### DIFF
--- a/pycoin/coins/groestlcoin/Block.py
+++ b/pycoin/coins/groestlcoin/Block.py
@@ -1,0 +1,13 @@
+import io
+
+from pycoin.encoding.hash import groestlHash
+from pycoin.block import Block as BaseBlock
+
+from .Tx import Tx
+
+class Block(BaseBlock):
+    Tx = Tx
+    def _calculate_hash(self):
+        s = io.BytesIO()
+        self.stream_header(s)
+        return groestlHash(s.getvalue())

--- a/pycoin/coins/groestlcoin/SolutionChecker.py
+++ b/pycoin/coins/groestlcoin/SolutionChecker.py
@@ -1,0 +1,51 @@
+import io
+
+from ...encoding.hash import sha256
+from pycoin.coins.bitcoin.SolutionChecker import BitcoinSolutionChecker
+
+from pycoin.satoshi.satoshi_struct import stream_struct
+
+from pycoin.satoshi.flags import (
+    SIGHASH_NONE, SIGHASH_SINGLE, SIGHASH_ANYONECANPAY,
+    VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM, VERIFY_CLEANSTACK, VERIFY_WITNESS
+)
+
+
+class GroestlcoinSolutionChecker(BitcoinSolutionChecker):
+    def _hash_prevouts(self, hash_type):
+        if hash_type & SIGHASH_ANYONECANPAY:
+            return ZERO32
+        f = io.BytesIO()
+        for tx_in in self.tx.txs_in:
+            f.write(tx_in.previous_hash)
+            stream_struct("L", f, tx_in.previous_index)
+        return sha256(f.getvalue())
+
+    def _hash_sequence(self, hash_type):
+        if (
+                (hash_type & SIGHASH_ANYONECANPAY) or
+                ((hash_type & 0x1f) == SIGHASH_SINGLE) or
+                ((hash_type & 0x1f) == SIGHASH_NONE)
+        ):
+            return ZERO32
+
+        f = io.BytesIO()
+        for tx_in in self.tx.txs_in:
+            stream_struct("L", f, tx_in.sequence)
+        return sha256(f.getvalue())
+
+    def _hash_outputs(self, hash_type, tx_in_idx):
+        txs_out = self.tx.txs_out
+        if hash_type & 0x1f == SIGHASH_SINGLE:
+            if tx_in_idx >= len(txs_out):
+                return ZERO32
+            txs_out = txs_out[tx_in_idx:tx_in_idx+1]
+        elif hash_type & 0x1f == SIGHASH_NONE:
+            return ZERO32
+        f = io.BytesIO()
+        for tx_out in txs_out:
+            stream_struct("QS", f, tx_out.coin_value, tx_out.script)
+        return sha256(f.getvalue())
+
+    def _signature_for_hash_type_segwit(self, script, tx_in_idx, hash_type):
+        return from_bytes_32(sha256(self._segwit_signature_preimage(script, tx_in_idx, hash_type)))

--- a/pycoin/coins/groestlcoin/Solver.py
+++ b/pycoin/coins/groestlcoin/Solver.py
@@ -1,0 +1,5 @@
+from pycoin.coins.bitcoin.Solver import BitcoinSolver
+from .SolutionChecker import GroestlcoinSolutionChecker
+
+class GroestlcoinSolver(BitcoinSolver):
+    SolutionChecker = GroestlcoinSolutionChecker

--- a/pycoin/coins/groestlcoin/Tx.py
+++ b/pycoin/coins/groestlcoin/Tx.py
@@ -1,0 +1,30 @@
+import io
+
+from pycoin.coins.bitcoin.Tx import Tx as BaseTx
+from pycoin.convention import SATOSHI_PER_COIN
+from pycoin.encoding.hash import sha256, groestlHash
+from pycoin.satoshi.satoshi_struct import stream_struct
+
+from .Solver import GroestlcoinSolver as Solver
+from .SolutionChecker import GroestlcoinSolutionChecker as SolutionChecker
+
+class Tx(BaseTx):
+    SolutionChecker = SolutionChecker
+    Solver = Solver
+
+    MAX_MONEY = 105000000 * SATOSHI_PER_COIN
+
+    def hash(self, hash_type=None):
+        s = io.BytesIO()
+        self.stream(s, include_witness_data=False)
+        if hash_type is not None:
+            stream_struct("L", s, hash_type)
+        return sha256(s.getvalue())
+
+    def w_hash(self):
+        return sha256(self.as_bin())
+
+    def blanked_hash(self):
+        s = io.BytesIO()
+        self.stream(s, blank_solutions=True)
+        return sha256(s.getvalue())

--- a/pycoin/encoding/b58.py
+++ b/pycoin/encoding/b58.py
@@ -25,7 +25,7 @@ def a2b_base58(s):
     return from_long(v, prefix, 256, lambda x: x)
 
 
-def b2a_hashed_base58(data):
+def b2a_hashed_base58(data, checksum_hash=double_sha256):
     """
     A "hashed_base58" structure is a base58 integer (which looks like a string)
     with four bytes of hash data at the end. Bitcoin does this in several places,
@@ -33,17 +33,17 @@ def b2a_hashed_base58(data):
 
     This function turns data (of type "bytes") into its hashed_base58 equivalent.
     """
-    return b2a_base58(data + double_sha256(data)[:4])
+    return b2a_base58(data + checksum_hash(data)[:4])
 
 
-def a2b_hashed_base58(s):
+def a2b_hashed_base58(s, checksum_hash=double_sha256):
     """
     If the passed string is hashed_base58, return the binary data.
     Otherwise raises an EncodingError.
     """
     data = a2b_base58(s)
     data, the_hash = data[:-4], data[-4:]
-    if double_sha256(data)[:4] == the_hash:
+    if checksum_hash(data)[:4] == the_hash:
         return data
     raise EncodingError("hashed base58 has bad checksum %s" % s)
 

--- a/pycoin/encoding/hash.py
+++ b/pycoin/encoding/hash.py
@@ -1,6 +1,8 @@
 
 import hashlib
 
+import groestlcoin_hash
+
 from .hexbytes import bytes_as_revhex
 
 
@@ -19,6 +21,10 @@ except Exception:
     from Crypto.Hash.RIPEMD import RIPEMD160Hash as ripemd160
 
 
+def sha256(data):
+    return bytes_as_revhex(hashlib.sha256(data).digest())
+
+
 def double_sha256(data):
     """A standard compound hash."""
     return bytes_as_revhex(hashlib.sha256(hashlib.sha256(data).digest()).digest())
@@ -27,6 +33,11 @@ def double_sha256(data):
 def hash160(data):
     """A standard compound hash."""
     return ripemd160(hashlib.sha256(data).digest()).digest()
+
+
+def groestlHash(data):
+    """Groestl-512 compound hash."""
+    return bytes_as_revhex(groestlcoin_hash.getHash(data, len(data)))
 
 
 """

--- a/pycoin/networks/bitcoinish.py
+++ b/pycoin/networks/bitcoinish.py
@@ -163,7 +163,7 @@ def create_bitcoinish_network(symbol, network_name, subnet_name, **kwargs):
     network.script_info = ScriptInfo(network.script_tools)
 
     UI_KEYS = ("bip32_prv_prefix bip32_pub_prefix wif_prefix sec_prefix "
-               "address_prefix pay_to_script_prefix bech32_hrp").split()
+               "address_prefix pay_to_script_prefix bech32_hrp base58_checksum_hash").split()
     ui_kwargs = {k: kwargs[k] for k in UI_KEYS if k in kwargs}
 
     network.ui = UI(network.script_info, generator, **ui_kwargs)

--- a/pycoin/symbols/grs.py
+++ b/pycoin/symbols/grs.py
@@ -1,0 +1,15 @@
+from pycoin.coins.groestlcoin.Block import Block as GrsBlock
+from pycoin.coins.groestlcoin.Tx import Tx as GrsTx
+from pycoin.networks.bitcoinish import create_bitcoinish_network
+
+
+network = create_bitcoinish_network(
+    symbol="GRS", network_name="Groestlcoin", subnet_name="mainnet", tx=GrsTx, block=GrsBlock,
+    wif_prefix_hex="80", sec_prefix="GRSSEC:", address_prefix_hex="24", pay_to_script_prefix_hex="05",
+    bip32_prv_prefix_hex="0488ade4", bip32_pub_prefix_hex="0488B21E", bech32_hrp="grs",
+    magic_header_hex="F9BEB4D9", default_port=1331,
+    dns_bootstrap=[
+        "groestlcoin.org", "electrum1.groestlcoin.org", "electrum2.groestlcoin.org",
+        "jswallet.groestlcoin.org", "groestlsight.groestlcoin.org"
+    ]
+)

--- a/pycoin/symbols/grs.py
+++ b/pycoin/symbols/grs.py
@@ -1,5 +1,6 @@
 from pycoin.coins.groestlcoin.Block import Block as GrsBlock
 from pycoin.coins.groestlcoin.Tx import Tx as GrsTx
+from pycoin.encoding.hash import groestlHash
 from pycoin.networks.bitcoinish import create_bitcoinish_network
 
 
@@ -7,6 +8,7 @@ network = create_bitcoinish_network(
     symbol="GRS", network_name="Groestlcoin", subnet_name="mainnet", tx=GrsTx, block=GrsBlock,
     wif_prefix_hex="80", sec_prefix="GRSSEC:", address_prefix_hex="24", pay_to_script_prefix_hex="05",
     bip32_prv_prefix_hex="0488ade4", bip32_pub_prefix_hex="0488B21E", bech32_hrp="grs",
+    base58_checksum_hash=groestlHash,
     magic_header_hex="F9BEB4D9", default_port=1331,
     dns_bootstrap=[
         "groestlcoin.org", "electrum1.groestlcoin.org", "electrum2.groestlcoin.org",

--- a/pycoin/ui/Parser.py
+++ b/pycoin/ui/Parser.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from pycoin.encoding.b58 import a2b_hashed_base58, EncodingError
+from pycoin.encoding.hash import double_sha256
 from pycoin.contrib import segwit_addr
 
 """
@@ -19,10 +20,10 @@ KEY:
 """
 
 
-def metadata_for_text(text):
+def metadata_for_text(text, checksum_hash=double_sha256):
     d = {}
     try:
-        data = a2b_hashed_base58(text)
+        data = a2b_hashed_base58(text, checksum_hash=checksum_hash)
         d["as_base58"] = (data,)
     except EncodingError:
         d["as_base58"] = None
@@ -65,14 +66,14 @@ def parse_to_info(metadata, parsers):
         return r
 
 
-def parse_all(item, parsers):
-    metadata = metadata_for_text(item)
+def parse_all(item, parsers, checksum_hash=double_sha256):
+    metadata = metadata_for_text(item, checksum_hash=checksum_hash)
     for info in parse_all_to_info(metadata, parsers):
         yield info.get("create_f")()
 
 
-def parse(item, parsers):
-    for r in parse_all(item, parsers):
+def parse(item, parsers, checksum_hash=double_sha256):
+    for r in parse_all(item, parsers, checksum_hash=checksum_hash):
         return r
 
 

--- a/pycoin/ui/key_from_text.py
+++ b/pycoin/ui/key_from_text.py
@@ -2,8 +2,8 @@ from pycoin.ui.Parser import metadata_for_text
 
 
 def key_info_from_text(text, networks):
-    metadata = metadata_for_text(text)
     for network in networks:
+        metadata = metadata_for_text(text, checksum_hash=network.ui._base58_checksum_hash)
         info = network.ui.parse_to_info(metadata, types=["key", "bip32", "electrum"])
         if info:
             yield network, info

--- a/pycoin/ui/validate.py
+++ b/pycoin/ui/validate.py
@@ -17,8 +17,8 @@ def is_address_valid(address, allowable_types=None, allowable_netcodes=None):
     a part of, or None if it doesn't validate.
     """
     networks = network_for_netcodes(allowable_netcodes)
-    metadata = metadata_for_text(address)
     for network in networks:
+        metadata = metadata_for_text(address, checksum_hash=network.ui._base58_checksum_hash)
         k = network.ui.parse_to_info(metadata, types=["address"])
         if k:
             if allowable_types is None or k.get("address_type") in allowable_types:
@@ -28,8 +28,8 @@ def is_address_valid(address, allowable_types=None, allowable_netcodes=None):
 
 def _is_key_valid(text, allowable_netcodes, info_filter_f, types=["key"]):
     networks = network_for_netcodes(allowable_netcodes)
-    metadata = metadata_for_text(text)
     for network in networks:
+        metadata = metadata_for_text(text, checksum_hash=network.ui._base58_checksum_hash)
         k = network.ui.parse_to_info(metadata, types=types)
         if k:
             if info_filter_f(k):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "pycoin.vm",
         "pycoin.wallet"
     ],
+    install_requires=['groestlcoin_hash'],
     author="Richard Kiss",
     entry_points={
         'console_scripts':

--- a/tests/grs/grs_block_test.py
+++ b/tests/grs/grs_block_test.py
@@ -1,0 +1,37 @@
+import io
+import unittest
+
+from pycoin.encoding.hexbytes import h2b
+from pycoin.networks.registry import network_for_netcode
+
+
+GroestlcoinMainnet = network_for_netcode("GRS")
+
+# Block 2000000
+BLOCK_HASH = '00000000000434d5b8d1c3308df7b6e3fd773657dfb28f5dd2f70854ef94cc66'
+
+class GroestlcoinBlockTestCase(unittest.TestCase):
+    def _get_block_stream(self):
+        return io.BytesIO(h2b('000000202c962905d18d95055e0b8d8f45ce748a44c119817058c23465b711000000000077da86d33f0c2e51b3e2aa2ba24551141edd68a1cc890e083521361993c31932c4f7a65aecf5141baa90713202010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff4c0380841e04c4f7a65a08fabe6d6d33312d33302d383130325b6d36335b1b3691506e2a97a2c14df7e9bc6e94e540010000000000000060000413010200000d2f6e6f64655374726174756d2f00000000020000000000000000266a24aa21a9ed8dfe2e8f6eb7ff2d6e27732d11c6aaee5eab7d5ea67b6cf887ec9d4cd038e831a876cd1d000000001976a91442bbcfb1cd88dbbb4c56086f1d018f10a7ef760688ac01200000000000000000000000000000000000000000000000000000000000000000000000000100000001f7b346fc08b41de682b81b7ce729edb2aeddc2f587b759859031e3bf99e68779000000006b483045022100e00b07400fbe10ee9396242557026ff6d3e16ffb46add2ccc5d7ffd8ddbc1989022003cc6832c4d62e15478150748867ca71eca04655f4b2ce31773832353d571647012102d4ad38a64b4ec115a77a900d6fb7f44343aa761ab6fcf8b8613443fa7e24e5befeffffff026e539827000000001976a9145db12e800001e767f56a3dbb202d0666315d063288acb5162400000000001976a914bd7b0274f1ef4325d0e8e273ed5be328bc3d11d988ac4a841e00'))
+
+    def test_block_hash(self):
+        parsed = GroestlcoinMainnet.block.parse(self._get_block_stream())
+        self.assertEqual(str(parsed.hash()), BLOCK_HASH)
+
+    def test_block_data(self):
+        parsed = GroestlcoinMainnet.block.parse(self._get_block_stream())
+        self.assertEqual(parsed.version, 536870912)
+        self.assertEqual(str(parsed.previous_block_hash), '000000000011b76534c258708119c1448a74ce458f8d0b5e05958dd10529962c')
+        self.assertEqual(str(parsed.merkle_root), '3219c39319362135080e89cca168dd1e145145a22baae2b3512e0c3fd386da77')
+        self.assertEqual(parsed.timestamp, 1520891844)
+        self.assertEqual(parsed.difficulty, int('1b14f5ec', 16))
+        self.assertEqual(parsed.nonce, 846303402)
+
+    def test_block_txs(self):
+        parsed = GroestlcoinMainnet.block.parse(self._get_block_stream())
+        tx = parsed.txs[0]
+        self.assertEqual(str(tx.hash()), '7a64cd89b9e0fd6b32be5deb349e460a90e6805278dee2fe301b347623f0806b')
+        self.assertTrue(tx.is_coinbase())
+
+        tx = parsed.txs[1]
+        self.assertEqual(str(tx.hash()), '89ff39e83636359bace69725fe19e1d33b16918205eaaf77c37684ac557e5154')

--- a/tests/grs/grs_encoding_test.py
+++ b/tests/grs/grs_encoding_test.py
@@ -1,0 +1,46 @@
+import unittest
+
+from pycoin.encoding.bytes32 import to_bytes_32
+from pycoin.encoding.hexbytes import h2b
+from pycoin.networks.registry import network_for_netcode
+
+
+GroestlcoinMainnet = network_for_netcode("GRS")
+
+class GroestlcoinEncodingTestCase(unittest.TestCase):
+    def test_p2pkh(self):
+        def do_test(h160, address):
+            self.assertEqual(GroestlcoinMainnet.ui.address_for_p2pkh(h160), address)
+            parsed = GroestlcoinMainnet.ui.parse(address)
+            self.assertEqual(parsed.as_text(), address)
+
+        do_test(h2b('0000000000000000000000000000000000000000'), 'FVAiSujNZVgYSc27t6zUTWoKfAGxer42D4')
+
+    def test_p2sh(self):
+        def do_test(h160, redeem_script, address):
+            self.assertEqual(GroestlcoinMainnet.script_info.script_for_p2sh(h160), redeem_script)
+            self.assertEqual(GroestlcoinMainnet.ui.address_for_p2sh(h160), address)
+
+        do_test(h2b('2a84cf00d47f699ee7bbc1dea5ec1bdecb4ac154'), h2b('a9142a84cf00d47f699ee7bbc1dea5ec1bdecb4ac15487'), '35ZqQJcBQMZ1rsv8aSuJ2wkC7ohUFNJZ77')
+
+    def test_wif(self):
+        def do_test(sec_bytes, wif, address):
+            parsed = GroestlcoinMainnet.ui.parse(wif)
+            self.assertEqual(to_bytes_32(parsed.secret_exponent()), sec_bytes)
+            self.assertEqual(parsed.wif(), wif)
+            self.assertEqual(parsed.address(), address)
+
+        do_test(h2b('0000000000000000000000000000000000000000000000000000000000000001'), '5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAmVmAPb', 'FiT6218RsUiTMyG5DA8bDjrNNuofYV2MdF')
+        do_test(h2b('0000000000000000000000000000000000000000000000000000000000000001'), 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sX6ptSt', 'Ffqz14cyvZYJavD76t6oHNDJnGiWcZMVxR')
+
+    def test_bip32(self):
+        xprv = 'xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3GaoVXP'
+        xpub = 'xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJuY6NHg'
+        parsed = GroestlcoinMainnet.ui.parse(xprv)
+        self.assertEqual(parsed.tree_depth(), 5)
+        self.assertEqual(parsed.parent_fingerprint(), b'\xd8\x80\xd7\xd8')
+        self.assertEqual(parsed.child_index(), 1000000000)
+        self.assertEqual(parsed.chain_code(), b'\xc7\x83\xe6{\x92\x1d+\xeb\x8fk8\x9c\xc6F\xd7&;AEp\x1d\xad\xd2\x16\x15H\xa8\xb0x\xe6^\x9e')
+        self.assertEqual(parsed.secret_exponent(), 32162737660659799401901343156672072893797470137297259782459076395168682141640)
+        self.assertEqual(parsed.hwif(as_private=True), xprv)
+        self.assertEqual(parsed.hwif(as_private=False), xpub)


### PR DESCRIPTION
Add Groestlcoin support. This change requires adding a new optional argument when creating a "bitcoinish" network: The hash algorithm used to create checksums in base58 encoding.

This also creates a dependency, `groestlcoin_hash`. If adding a dependency is a problem, it could be possible to refactor so that GRS is only supported if `groestlcoin_hash` is (optionally) installed.

Please advise regarding whether the required changes to pycoin should be implemented differently.