### PR TITLE
correct generation of r and recid

### DIFF
--- a/pycoin/ecdsa/Generator.py
+++ b/pycoin/ecdsa/Generator.py
@@ -134,11 +134,11 @@ class Generator(Curve, Point):
         k = gen_k(n, secret_exponent, val)
         while True:
             p1 = k * self
-            r = p1[0]
+            r = p1[0] % n
             s = (self.inverse(k) * (val + (secret_exponent * r) % n)) % n
             if r != 0 and s != 0:
                 recid = p1[1] & 1
-                if p1[1] > self._p:
+                if p1[0] > n:
                     recid += 2
                 return r, s, recid
             k += 1


### PR DESCRIPTION
- According to sec1-v2 (http://www.secg.org/sec1-v2.pdf) Section 4.1.3, r should be modulo by curve.order;
- p1[1] would never greater than curve.p due to the modulo curve.p operation in Curve.add();
    - https://github.com/richardkiss/pycoin/blob/master/pycoin/ecdsa/Curve.py#L67
- recovery id is added with 2 in the overflow condition when p1[0] > curve.order;
    - https://github.com/indutny/elliptic/blob/776c9b0e99832ab9fa6c5fa6f684c484ca5265b2/lib/elliptic/ec/index.js#L141
    - https://github.com/bitcoin-core/secp256k1/blob/1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c/src/ecdsa_impl.h#L288
- There is only 1/2^127 chance to trigger this overflow condition (A.K.A, this bug);