### PR TITLE
Retain generators when Keys are transformed to related formats.

### DIFF
--- a/pycoin/key/Key.py
+++ b/pycoin/key/Key.py
@@ -214,20 +214,17 @@ class Key(object):
         r, s = self._generator.sign(self.secret_exponent(), val)
         return sigencode_der(r, s)
 
-    def verify(self, h, sig, generator=None):
+    def verify(self, h, sig):
         """
         Return whether a signature is valid for hash h using this key.
         """
-        generator = generator or self._generator
-        if not generator:
-            raise ValueError("generator must be specified")
         val = from_bytes_32(h)
         pubkey = self.public_pair()
         rs = sigdecode_der(sig)
         if self.public_pair() is None:
             # find the pubkey from the signature and see if it matches
             # our key
-            possible_pubkeys = generator.possible_public_pairs_for_signature(val, rs)
+            possible_pubkeys = self._generator.possible_public_pairs_for_signature(val, rs)
             hash160 = self.hash160()
             for candidate in possible_pubkeys:
                 if hash160 == public_pair_to_hash160_sec(candidate, True):
@@ -239,7 +236,7 @@ class Key(object):
             else:
                 # signature is using a pubkey that's not this key
                 return False
-        return generator.verify(pubkey, val, rs)
+        return self._generator.verify(pubkey, val, rs)
 
     def _use_uncompressed(self, use_uncompressed=None):
         if use_uncompressed:

--- a/pycoin/key/Key.py
+++ b/pycoin/key/Key.py
@@ -86,7 +86,7 @@ class Key(object):
         """
         generator = generator or class_._default_generator
         public_pair = sec_to_public_pair(sec, generator)
-        return class_(public_pair=public_pair, is_compressed=is_sec_compressed(sec))
+        return class_(public_pair=public_pair, generator=generator, is_compressed=is_sec_compressed(sec))
 
     def is_private(self):
         return self.secret_exponent() is not None

--- a/pycoin/key/Key.py
+++ b/pycoin/key/Key.py
@@ -184,7 +184,9 @@ class Key(object):
         if self.secret_exponent() is None:
             return self
 
-        return self.__class__(public_pair=self.public_pair(), prefer_uncompressed=self._prefer_uncompressed,
+        return self.__class__(public_pair=self.public_pair(),
+                              generator=self._generator,
+                              prefer_uncompressed=self._prefer_uncompressed,
                               is_compressed=(self._hash160_compressed is not None))
 
     def subkey_for_path(self, path):

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -18,9 +18,9 @@ class KeyTest(unittest.TestCase):
         sig = private_key.sign(h)
         self.assertTrue(private_key.verify(h, sig))
         public_key = private_key.public_copy()
-        self.assertTrue(public_key.verify(h, sig, generator=secp256k1_generator))
+        self.assertTrue(public_key.verify(h, sig))
         h160_key = Key(hash160=private_key.hash160())
-        self.assertTrue(h160_key.verify(h, sig, generator=secp256k1_generator))
+        self.assertTrue(h160_key.verify(h, sig))
 
     def test_translation(self):
         def do_test(exp_hex, wif, c_wif, public_pair_sec, c_public_pair_sec, address_b58, c_address_b58):


### PR DESCRIPTION
**EDIT**: I thought better about how I was using this. See below.

----

This code works

```
    from pycoin.symbols.btc import network as btc

    xpriv = "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
    key = btc.ui.parse(xpriv)
    m = hashlib.sha256(b"some text").digest()

    s = key.sign(m)

    # do test verification
    pubkey = key.public_copy()
    if not pubkey.verify(m, s):
        raise RuntimeError("Failed to verify.")
```

but this code, where I've made a small tweak to use secp256r1 instead of secp256k1, fails:

```
    from pycoin.symbols.btc import network as btc
    from pycoin.ecdsa.secp256r1 import secp256r1_generator

    xpriv = "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
    key = btc.ui.parse(xpriv)
    m = hashlib.sha256(b"some text").digest()

    s = key.sign(m, generator=secp256r1_generator)

    # do test verification
    pubkey = key.public_copy()
    if not pubkey.verify(m, s, generator=secp256r1):
        raise RuntimeError("Failed to verify.")
```

This PR patches the problem!