### PR TITLE
Fixed 2 issues of type: PYTHON_E241 throughout 2 files in repo.

### DIFF
--- a/tests/btc/bip32_test.py
+++ b/tests/btc/bip32_test.py
@@ -245,7 +245,7 @@ class Bip0032TestCase(unittest.TestCase):
 
         address = wallet.address()
         pub_k = XTN.parse.address(address)
-        self.assertEqual(repr(pub_k),  '<myb5gZNXePNf2E2ksrjnHRFCwyuvt7oEay>')
+        self.assertEqual(repr(pub_k), '<myb5gZNXePNf2E2ksrjnHRFCwyuvt7oEay>')
 
         wif = wallet.wif()
         priv_k = XTN.parse.secret(wif)

--- a/tests/key_validate_test.py
+++ b/tests/key_validate_test.py
@@ -107,7 +107,7 @@ class KeyUtilsTest(unittest.TestCase):
 
         address = key.address()
         pub_k = XTN.parse(address)
-        self.assertEqual(repr(pub_k),  '<mhDVBkZBWLtJkpbszdjZRkH1o5RZxMwxca>')
+        self.assertEqual(repr(pub_k), '<mhDVBkZBWLtJkpbszdjZRkH1o5RZxMwxca>')
 
         wif = key.wif()
         priv_k = XTN.parse.wif(wif)


### PR DESCRIPTION
PYTHON_E241: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.