### PR TITLE
Fixed 2 issues of type: PYTHON_F401 throughout 2 files in repo.

### DIFF
--- a/pycoin/solve/some_solvers.py
+++ b/pycoin/solve/some_solvers.py
@@ -1,6 +1,5 @@
 # generic solver
 
-import pdb
 
 from pycoin.coins.SolutionChecker import ScriptError
 from pycoin.satoshi.checksigops import parse_signature_blob

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-import doctest
 
 
 def load_tests(loader, tests, ignore):


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        