### PR TITLE
Fixed 3 issues of type: PYTHON_F841 throughout 3 files in repo.

### DIFF
--- a/pycoin/cmds/ku.py
+++ b/pycoin/cmds/ku.py
@@ -147,7 +147,7 @@ def _create_bip32(network):
     for _ in range(max_retries):
         try:
             return network.keys.bip32_seed(get_entropy())
-        except ValueError as e:
+        except ValueError:
             continue
     # Probably a bug if we get here
     raise RuntimeError("can't create BIP32 key")

--- a/tests/solver_test.py
+++ b/tests/solver_test.py
@@ -98,7 +98,7 @@ class SolverTest(unittest.TestCase):
         self.do_test_tx(script, p2sh_lookup=network.tx.solve.build_p2sh_lookup([underlying_script, p2sh_script]))
 
     def test_if(self):
-        script = network.script.compile("IF 1 ELSE 0 ENDIF")
+        network.script.compile("IF 1 ELSE 0 ENDIF")
         # self.do_test_tx(script)
 
     def test_p2multisig_incremental(self):


### PR DESCRIPTION

        PYTHON_F841: 'local variable is assigned to but never used.'
PYTHON_F401: 'Module imported but unused.'

This is a more aggressive PR which tries to prune out unused modules and variables.

Modules or variables with global, implicit side-effects could cause issues if removed.
Please check carefully.  This fix was done using <a href='https://github.com/myint/autoflake'>autoflake</a>. 
        