### PR TITLE
Round down deterministic-K input at the edge of the group size

### DIFF
--- a/pycoin/ecdsa/rfc6979.py
+++ b/pycoin/ecdsa/rfc6979.py
@@ -37,7 +37,7 @@ def deterministic_generate_k(generator_order, secret_exponent, val, hash_f=hashl
     shift = 8 * hash_size - bln
     if shift > 0:
         val >>= shift
-    if val > n:
+    if val >= n:
         val -= n
     h1 = intstream.to_bytes(val, length=order_size)
     k = hmac.new(k, v + b'\x00' + priv + h1, hash_f).digest()


### PR DESCRIPTION
Hi Richard, I hope you are well 🐰

I believe the implementation has a tiny mistake that occurs when the input happens
to equal the group order (eg `z = p256k1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`).

https://tools.ietf.org/html/rfc6979#section-2.3.4 says:
>    2.  z1 is reduced modulo q, yielding z2 (an integer between 0 and
>       q-1, inclusive):
>
>          z2 = z1 mod q
>
>       Note that since z1 is less than 2^qlen, that modular reduction
>       can be implemented with a simple conditional subtraction:
>       z2 = z1-q if that value is non-negative; otherwise, z2 = z1.

Here val = z1, and n = q. It's saying:
```
z2 = z1 - q if (z1 - q >= 0) else z1
```
which is the same as
```
val = z1; n = q;
if val - n >= 0:
  val = val - n
```

which is the same as
```
if val >= n:
  val -= n
```

Without this this input uses the wrong nonce.