### PR TITLE
Disallow the zero ECDSA message.

### DIFF
--- a/pycoin/ecdsa/Generator.py
+++ b/pycoin/ecdsa/Generator.py
@@ -145,6 +145,8 @@ class Generator(Curve, Point):
             of ``val`` using ``public_pair`` public key.
         """
         order = self._order
+        if val == 0:
+            return False
         r, s = sig
         if r < 1 or r >= order or s < 1 or s >= order:
             return False
@@ -170,6 +172,8 @@ class Generator(Curve, Point):
         K value should be returned. Otherwise, the default K value, generated according
         to rfc6979 will be used.
         """
+        if val == 0:
+            raise ValueError()
         if gen_k is None:
             gen_k = deterministic_generate_k
         n = self._order

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -8,7 +8,7 @@ class KeyTest(unittest.TestCase):
 
     def test_sign_verify(self):
         private_key = network.keys.private(secret_exponent=1)
-        h = b"\x00" * 32
+        h = b"\x16" * 32
         sig = private_key.sign(h)
         self.assertTrue(private_key.verify(h, sig))
         public_key = private_key.public_copy()


### PR DESCRIPTION
ECDSA has a subtle edge case. If the value to sign is 0, then anyone can forge a signature
by picking (r,s) = (public_key.x, public_key.x).
ref: https://crypto.stackexchange.com/questions/50279/how-should-ecdsa-handle-the-null-hash

Signing is --- working mod n --- supposed to be this:

(x,y) := k*G
r := x
s := inverse(k) * (val + (secret_exponent * r))

and verifying is

u1 := val * inverse(s)
u2 := r * inverse(s)
(x',y') := u1 * G + u2 * public_key
         = (val*inverse(s)) * G + (r * inverse(s)) * public_key

But if val = 0 this collapses to
         = (0*inverse(s)) * G + (r * inverse(s)) * public_key
         = (r * inverse(s)) * public_key

And then as a forger I can lie and pick s := r so that this becomes
         = (r * inverse(r)) * public_key
         = public_key

So I know what value I need r to be to pass verification: r := public_key.x.

So the zero hash is not safe to sign with ECDSA.

The [ecdsa spec](http://www.secg.org/sec1-v2.pdf#subsubsection.4.1.3) covers a bunch of special cases that don't work (r = 0, s = 0, (x',y') = (0,0)) but it doesn't mention this one.