### PR TITLE
Fixing Key when not calling make_subclass()

### DIFF
--- a/pycoin/key/Key.py
+++ b/pycoin/key/Key.py
@@ -50,6 +50,13 @@ class Key(object):
         self._hash160_uncompressed = None
         self._hash160_compressed = None
 
+        if self._generator is None:
+            from pycoin.ecdsa.secp256k1 import secp256k1_generator
+            self._generator = secp256k1_generator
+        if self._network is None:
+            from pycoin.networks.default import get_current_network
+            self._network = get_current_network()
+
         if self._secret_exponent is not None:
             if self._secret_exponent < 1 \
                     or self._secret_exponent >= self._generator.order():


### PR DESCRIPTION
Before:
```
>>> import pycoin
>>> pycoin.version
'0.80'
>>> from mnemonic import Mnemonic
>>> from pycoin.key.BIP32Node import BIP32Node
>>> mnemonic = "1"
>>> master_key = BIP32Node.from_master_secret(Mnemonic("english").to_seed(mnemonic))
>>> master_key
private_for <xpub661MyMwAqRbcGCnxNNBY2fqEQz49Caej3Vazphu2t3Anf4JvdDVAtAdsu4BLGCgN2CLU6LNZXvVAiogeHBDggX4RsL6MPKpaPo8HBY2uTND>
```

Now:
```
>>> import pycoin
>>> pycoin.version
'0.90.20190630'
>>> from mnemonic import Mnemonic
>>> from pycoin.key.BIP32Node import BIP32Node
>>> mnemonic = "1"
>>> master_key = BIP32Node.from_master_secret(Mnemonic("english").to_seed(mnemonic))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python3.6/site-packages/pycoin/key/BIP32Node.py", line 44, in from_master_secret
    return class_(chain_code=I64[32:], secret_exponent=from_bytes_32(I64[:32]))
  File ".../python3.6/site-packages/pycoin/key/BIP32Node.py", line 66, in __init__
    secret_exponent=secret_exponent, public_pair=public_pair, is_compressed=True)
  File ".../lib/python3.6/site-packages/pycoin/key/Key.py", line 55, in __init__
    or self._secret_exponent >= self._generator.order():
AttributeError: 'NoneType' object has no attribute 'order'
```

If there is a "new" proper way to call `BIP32Node.from_master_secret()`, please let me know and feel free to close this.
