### PR TITLE
allow None as default_placeholder when signing tx

### DIFF
--- a/pycoin/vm/ScriptTools.py
+++ b/pycoin/vm/ScriptTools.py
@@ -93,4 +93,4 @@ class ScriptTools(object):
             f.write(self.scriptStreamer.compile_push_data(t))
 
     def compile_push_data_list(self, data_list):
-        return b''.join(self.scriptStreamer.compile_push_data(d) for d in data_list)
+        return b''.join(self.scriptStreamer.compile_push_data(d) for d in data_list if d is not None)


### PR DESCRIPTION
Upgrading from `0.80` to `0.90.20200322` the call below is now broken. This PR fixes the issue of having `signature_placeholder = None`.
```python
signature_placeholder = None
network.tx_utils.sign_tx(
    tx, wifs=private_keys, p2sh_lookup=p2sh_lookup, hash_type=network.validator.flags.SIGHASH_ALL | SIGHASH_FORKID,
    signature_placeholder=signature_placeholder
)
```
Stack trace
```
venv/lib/python3.6/site-packages/pycoin/networks/bitcoinish.py:275: in my_sign_tx
    return sign_tx(network, *args, **kwargs)
venv/lib/python3.6/site-packages/pycoin/coins/tx_utils.py:131: in sign_tx
    solver.sign(keychain, **kwargs)
venv/lib/python3.6/site-packages/pycoin/coins/bitcoin/Solver.py:170: in sign
    r = self.solve(hash160_lookup, tx_in_idx, hash_type=hash_type, **kwargs)
venv/lib/python3.6/site-packages/pycoin/coins/bgold/Solver.py:14: in solve
    return super(BgoldSolver, self).solve(*args, **kwargs)
venv/lib/python3.6/site-packages/pycoin/coins/bitcoin/Solver.py:145: in solve
    solution_script = self.ScriptTools.compile_push_data_list(solution_list)
venv/lib/python3.6/site-packages/pycoin/vm/ScriptTools.py:96: in compile_push_data_list
    return b''.join(self.scriptStreamer.compile_push_data(d) for d in data_list)
venv/lib/python3.6/site-packages/pycoin/vm/ScriptTools.py:96: in <genexpr>
    return b''.join(self.scriptStreamer.compile_push_data(d) for d in data_list)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pycoin.vm.ScriptStreamer.ScriptStreamer object at 0x7f51ca13f278>, data = None

    def compile_push_data(self, data):
        # return bytes that causes the given data to be pushed onto the stack
        if data in self.const_encoder:
            return self.const_encoder.get(data)
>       size = len(data)
E       TypeError: object of type 'NoneType' has no len()

venv/lib/python3.6/site-packages/pycoin/vm/ScriptStreamer.py:157: TypeError
```