### PR TITLE
docs: fix simple typo, mulitiplication -> multiplication

### DIFF
--- a/pycoin/ecdsa/native/openssl.py
+++ b/pycoin/ecdsa/native/openssl.py
@@ -98,7 +98,7 @@ def create_OpenSSLOptimizations(curve_id):
             openssl_group = OpenSSL.EC_GROUP_new_by_curve_name(curve_id)
 
         def multiply(self, p, e):
-            "Use OpenSSL to perform point mulitiplication."
+            "Use OpenSSL to perform point multiplication."
             if e == 0 or p == self._infinity:
                 return self._infinity
 


### PR DESCRIPTION
There is a small typo in pycoin/ecdsa/native/openssl.py.

Should read `multiplication` rather than `mulitiplication`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md