### PR TITLE
Add segwit xpub support

### DIFF
--- a/pycoin/networks/AddressAPI.py
+++ b/pycoin/networks/AddressAPI.py
@@ -9,8 +9,9 @@ from pycoin.intbytes import iterbytes
 
 def make_address_api(
         contracts,
-        bip32_prv_prefix=None, bip32_pub_prefix=None, wif_prefix=None,
-        sec_prefix=None, address_prefix=None, pay_to_script_prefix=None,
+        bip32_prv_prefix=None, bip32_pub_prefix=None, bip49_prv_prefix=None,
+        bip49_pub_prefix=None, bip84_prv_prefix=None, bip84_pub_prefix=None,
+        wif_prefix=None, sec_prefix=None, address_prefix=None, pay_to_script_prefix=None,
         bech32_hrp=None):
 
     class AddressAPI(object):

--- a/pycoin/networks/ParseAPI.py
+++ b/pycoin/networks/ParseAPI.py
@@ -78,6 +78,16 @@ class ParseAPI(object):
         s = parseable_str(s)
         return self.bip32_prv(s) or self.bip32_pub(s)
 
+    def bip49_prv(self, s):
+        """
+        Parse a bip84 private key from a text string ("zprv" type).
+        Return a :class:`BIP32 <pycoin.key.BIP32Node.BIP32Node>` or None.
+        """
+        data = self.parse_b58_hashed(s)
+        if data is None or not data.startswith(self._bip49_prv_prefix):
+            return None
+        return self._network.keys.bip32_deserialize(data, pay_to_script_wit=True)
+
     def bip49_pub(self, s):
         """
         Parse a bip84 public key from a text string ("ypub" type).
@@ -88,6 +98,24 @@ class ParseAPI(object):
             return None
         return self._network.keys.bip32_deserialize(data, pay_to_script_wit=True)
 
+    def bip84_prv(self, s):
+        """
+        Parse a bip84 private key from a text string ("zprv" type).
+        Return a :class:`BIP32 <pycoin.key.BIP32Node.BIP32Node>` or None.
+        """
+        data = self.parse_b58_hashed(s)
+        if data is None or not data.startswith(self._bip84_prv_prefix):
+            return None
+        return self._network.keys.bip32_deserialize(data, pay_to_native_wit=True)
+
+    def bip49(self, s):
+        """
+        Parse a bip49 public key from a text string, either a seed, a prv or a pub.
+        Return a :class:`BIP32 <pycoin.key.BIP32Node.BIP32Node>` or None.
+        """
+        s = parseable_str(s)
+        return self.bip49_prv(s) or self.bip49_pub(s)
+
     def bip84_pub(self, s):
         """
         Parse a bip84 public key from a text string ("zpub" type).
@@ -97,6 +125,14 @@ class ParseAPI(object):
         if data is None or not data.startswith(self._bip84_pub_prefix):
             return None
         return self._network.keys.bip32_deserialize(data, pay_to_native_wit=True)
+
+    def bip84(self, s):
+        """
+        Parse a bip84 public key from a text string, either a seed, a prv or a pub.
+        Return a :class:`BIP32 <pycoin.key.BIP32Node.BIP32Node>` or None.
+        """
+        s = parseable_str(s)
+        return self.bip84_prv(s) or self.bip84_pub(s)
 
     def _electrum_to_blob(self, s):
         pair = parse_colon_prefix(s)
@@ -313,7 +349,8 @@ class ParseAPI(object):
         """
         s = parseable_str(s)
         for f in [self.bip32_seed, self.bip32_prv, self.bip32_pub, self.bip49_pub,
-                  self.bip84_pub, self.electrum_seed, self.electrum_prv, self.electrum_pub]:
+                  self.bip49_prv, self.bip84_prv, self.bip84_pub, self.electrum_seed,
+                  self.electrum_prv, self.electrum_pub]:
             v = f(s)
             if v:
                 return v

--- a/pycoin/networks/ParseAPI.py
+++ b/pycoin/networks/ParseAPI.py
@@ -78,6 +78,16 @@ class ParseAPI(object):
         s = parseable_str(s)
         return self.bip32_prv(s) or self.bip32_pub(s)
 
+    def bip49_pub(self, s):
+        """
+        Parse a bip84 public key from a text string ("ypub" type).
+        Return a :class:`BIP32 <pycoin.key.BIP32Node.BIP32Node>` or None.
+        """
+        data = self.parse_b58_hashed(s)
+        if data is None or not data.startswith(self._bip49_pub_prefix):
+            return None
+        return self._network.keys.bip32_deserialize(data, pay_to_script_wit=True)
+
     def bip84_pub(self, s):
         """
         Parse a bip84 public key from a text string ("zpub" type).
@@ -302,8 +312,8 @@ class ParseAPI(object):
         Return a subclass of :class:`Key <pycoin.key.Key>`, or None.
         """
         s = parseable_str(s)
-        for f in [self.bip32_seed, self.bip32_prv, self.bip32_pub, self.bip84_pub,
-                  self.electrum_seed, self.electrum_prv, self.electrum_pub]:
+        for f in [self.bip32_seed, self.bip32_prv, self.bip32_pub, self.bip49_pub,
+                  self.bip84_pub, self.electrum_seed, self.electrum_prv, self.electrum_pub]:
             v = f(s)
             if v:
                 return v

--- a/pycoin/networks/ParseAPI.py
+++ b/pycoin/networks/ParseAPI.py
@@ -10,11 +10,16 @@ from .Contract import Contract
 
 class ParseAPI(object):
     def __init__(
-            self, network, bip32_prv_prefix=None, bip32_pub_prefix=None, address_prefix=None,
+            self, network, bip32_prv_prefix=None, bip32_pub_prefix=None, bip49_prv_prefix=None,
+            bip49_pub_prefix=None, bip84_prv_prefix=None, bip84_pub_prefix=None, address_prefix=None,
             pay_to_script_prefix=None, bech32_hrp=None, wif_prefix=None, sec_prefix=None):
         self._network = network
         self._bip32_prv_prefix = bip32_prv_prefix
         self._bip32_pub_prefix = bip32_pub_prefix
+        self._bip49_prv_prefix = bip49_prv_prefix
+        self._bip49_pub_prefix = bip49_pub_prefix
+        self._bip84_prv_prefix = bip84_prv_prefix
+        self._bip84_pub_prefix = bip84_pub_prefix
         self._address_prefix = address_prefix
         self._pay_to_script_prefix = pay_to_script_prefix
         self._bech32_hrp = bech32_hrp
@@ -72,6 +77,16 @@ class ParseAPI(object):
         """
         s = parseable_str(s)
         return self.bip32_prv(s) or self.bip32_pub(s)
+
+    def bip84_pub(self, s):
+        """
+        Parse a bip84 public key from a text string ("zpub" type).
+        Return a :class:`BIP32 <pycoin.key.BIP32Node.BIP32Node>` or None.
+        """
+        data = self.parse_b58_hashed(s)
+        if data is None or not data.startswith(self._bip84_pub_prefix):
+            return None
+        return self._network.keys.bip32_deserialize(data, pay_to_native_wit=True)
 
     def _electrum_to_blob(self, s):
         pair = parse_colon_prefix(s)
@@ -287,7 +302,7 @@ class ParseAPI(object):
         Return a subclass of :class:`Key <pycoin.key.Key>`, or None.
         """
         s = parseable_str(s)
-        for f in [self.bip32_seed, self.bip32_prv, self.bip32_pub,
+        for f in [self.bip32_seed, self.bip32_prv, self.bip32_pub, self.bip84_pub,
                   self.electrum_seed, self.electrum_prv, self.electrum_pub]:
             v = f(s)
             if v:

--- a/pycoin/networks/bitcoinish.py
+++ b/pycoin/networks/bitcoinish.py
@@ -151,7 +151,8 @@ def create_bitcoinish_network(symbol, network_name, subnet_name, **kwargs):
     script_tools = kwargs.get("script_tools", BitcoinScriptTools)
 
     UI_KEYS = ("bip32_prv_prefix bip32_pub_prefix bip49_prv_prefix bip49_pub_prefix "
-               "bip84_prv_prefix bip84_pub_prefix wif_prefix address_prefix").split()
+               "bip84_prv_prefix bip84_pub_prefix wif_prefix address_prefix "
+               "address_prefix pay_to_script_prefix bech32_hrp").split()
     ui_kwargs = {k: kwargs[k] for k in UI_KEYS if k in kwargs}
 
     _bip32_prv_prefix = ui_kwargs.get("bip32_prv_prefix")

--- a/pycoin/networks/bitcoinish.py
+++ b/pycoin/networks/bitcoinish.py
@@ -140,7 +140,8 @@ def create_bitcoinish_network(symbol, network_name, subnet_name, **kwargs):
 
     generator = kwargs.get("generator", secp256k1_generator)
     kwargs.setdefault("sec_prefix", "%sSEC" % symbol.upper())
-    KEYS_TO_H2B = ("bip32_prv_prefix bip32_pub_prefix wif_prefix address_prefix "
+    KEYS_TO_H2B = ("bip32_prv_prefix bip32_pub_prefix bip49_prv_prefix bip49_pub_prefix "
+                   "bip84_prv_prefix bip84_pub_prefix wif_prefix address_prefix "
                    "pay_to_script_prefix sec_prefix magic_header").split()
     for k in KEYS_TO_H2B:
         k_hex = "%s_hex" % k
@@ -149,12 +150,16 @@ def create_bitcoinish_network(symbol, network_name, subnet_name, **kwargs):
 
     script_tools = kwargs.get("script_tools", BitcoinScriptTools)
 
-    UI_KEYS = ("bip32_prv_prefix bip32_pub_prefix wif_prefix sec_prefix "
-               "address_prefix pay_to_script_prefix bech32_hrp").split()
+    UI_KEYS = ("bip32_prv_prefix bip32_pub_prefix bip49_prv_prefix bip49_pub_prefix "
+               "bip84_prv_prefix bip84_pub_prefix wif_prefix address_prefix").split()
     ui_kwargs = {k: kwargs[k] for k in UI_KEYS if k in kwargs}
 
     _bip32_prv_prefix = ui_kwargs.get("bip32_prv_prefix")
     _bip32_pub_prefix = ui_kwargs.get("bip32_pub_prefix")
+    _bip49_prv_prefix = ui_kwargs.get("bip49_prv_prefix")
+    _bip49_pub_prefix = ui_kwargs.get("bip49_pub_prefix")
+    _bip84_prv_prefix = ui_kwargs.get("bip84_prv_prefix")
+    _bip84_pub_prefix = ui_kwargs.get("bip84_pub_prefix")
     _wif_prefix = ui_kwargs.get("wif_prefix")
     _sec_prefix = ui_kwargs.get("sec_prefix")
 
@@ -228,8 +233,8 @@ def create_bitcoinish_network(symbol, network_name, subnet_name, **kwargs):
     def bip32_seed(seed):
         return NetworkBIP32Node.from_master_secret(seed)
 
-    def bip32_deserialize(data):
-        return NetworkBIP32Node.deserialize(data)
+    def bip32_deserialize(data, pay_to_script_wit=False, pay_to_native_wit=False):
+        return NetworkBIP32Node.deserialize(data, pay_to_script_wit=pay_to_script_wit, pay_to_native_wit=pay_to_native_wit)
 
     network.keys.bip32_seed = bip32_seed
     network.keys.bip32_deserialize = bip32_deserialize

--- a/pycoin/symbols/btc.py
+++ b/pycoin/symbols/btc.py
@@ -4,8 +4,9 @@ from pycoin.networks.bitcoinish import create_bitcoinish_network
 network = create_bitcoinish_network(
     symbol="BTC", network_name="Bitcoin", subnet_name="mainnet",
     wif_prefix_hex="80", sec_prefix="BTCSEC:", address_prefix_hex="00", pay_to_script_prefix_hex="05",
-    bip32_prv_prefix_hex="0488ade4", bip32_pub_prefix_hex="0488B21E", bech32_hrp="bc",
-    magic_header_hex="F9BEB4D9", default_port=8333,
+    bip32_prv_prefix_hex="0488ade4", bip32_pub_prefix_hex="0488B21E", bip49_prv_prefix_hex="049d7878",
+    bip49_pub_prefix_hex="049D7CB2", bip84_prv_prefix_hex="04b2430c", bip84_pub_prefix_hex="04B24746",
+    bech32_hrp="bc", magic_header_hex="F9BEB4D9", default_port=8333,
     dns_bootstrap=[
         "seed.bitcoin.sipa.be", "dnsseed.bitcoin.dashjr.org",
         "bitseed.xf2.org", "dnsseed.bluematt.me",

--- a/tests/keyparser_test.py
+++ b/tests/keyparser_test.py
@@ -40,17 +40,29 @@ class KeyParserTest(unittest.TestCase):
                         "ncCKZKgb5jZoY5eSJMJ2Vbyvi2hbmQnCuHBujZ2WXGTux1X2k9Krdtr")
         self.assertEqual(key, None)
 
-    def test_parse_p2wpkh_native(self):
+    def test_parse_p2wpkh_priv(self):
+        key = BTC.parse("zprvAYkZ9vLqSk9bAb9xL9sZEKTUqbURWBYGhz8kU33d7k1zfNzJr4Wy"
+                        "jBqEs8iCWn6jATSJGHdmPUNWXAUHm3hX1f4XjFcP1YsQUvGR9zJd6e5")
+        subkey = key.subkey_for_path("0/0")
+        self.assertEqual(subkey.address(), "bc1qz0e8kyqvhr2j4xzlzr2r5rkpxykerv6vdawckn")
+
+    def test_parse_p2wpkh_pub(self):
         key = BTC.parse("zpub6mjuZRsjH7htP5ERSBQZbTQDPdJuueG85D4MGRTEg5YyYBKTPbqEGz9iiPmKkCrTn2dMFsp2tgs3MQ1zExvNFTEnHrrABy4dayJk9foR6K9")
         self.assertEqual(key.secret_exponent(), None)
         subkey = key.subkey_for_path("0/0")
         self.assertEqual(subkey.address(), "bc1qz0e8kyqvhr2j4xzlzr2r5rkpxykerv6vdawckn")
 
-    def test_parse_p2wpkh_in_p2sh(self):
-        key = BTC.parse("ypub6XBLL6jnweSSSPTqcwWAs8RXKKuN2FHH7LABWKE6aLoEnw5c2AbEBYSmQytdE1yDQtyJgdmi1K45ytkfDwrksXjefVCHw3thJ4xwyJPJnQk")
+    def test_parse_p2wpkh_in_p2sh_priv(self):
+        key = BTC.parse("yprvAHcaFzWG6Xu7N2Tum3WGs6gj4sbSv6DSrWyWgNaHmm6i9aHP8uG2f"
+                        "qUHzgHQc4S48Q5cfS8MfBdhCY32e15AZ6qVnXGzZsJe8njSKXh8Y3g")
+        subkey = key.subkey_for_path("0/0")
+        self.assertEqual(subkey.address(), "3F6bDarXnXbCsVuE5CbquM6ubg16qDRbHh")
+
+    def test_parse_p2wpkh_in_pub(self):
+        key = BTC.parse("ypub6WbvfW39vuTQaWYNs53HEEdTcuRwKYwJDju7UkyuL6dh2NcXgSaHDdnmqyg2sRSxXYCLix5r5JAEufkNeS2ugPj3UA6o98W7yWrcUzg8HoD")
         self.assertEqual(key.secret_exponent(), None)
         subkey = key.subkey_for_path("0/0")
-        self.assertEqual(subkey.address(), "3Q8QcAFXNRKSWmYDzjYzoZEMNrEf1jXaRG")
+        self.assertEqual(subkey.address(), "3F6bDarXnXbCsVuE5CbquM6ubg16qDRbHh")
 
     def test_parse_wif(self):
         key = BTC.parse("KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn")
@@ -73,8 +85,8 @@ class KeyParserTest(unittest.TestCase):
         self.assertEqual(key.address(), "bc1qz0e8kyqvhr2j4xzlzr2r5rkpxykerv6vdawckn")
 
     def test_parse_p2wpkh_in_p2sh_address(self):
-        key = BTC.parse("3Q8QcAFXNRKSWmYDzjYzoZEMNrEf1jXaRG")
-        self.assertEqual(key.address(), "3Q8QcAFXNRKSWmYDzjYzoZEMNrEf1jXaRG")
+        key = BTC.parse("3F6bDarXnXbCsVuE5CbquM6ubg16qDRbHh")
+        self.assertEqual(key.address(), "3F6bDarXnXbCsVuE5CbquM6ubg16qDRbHh")
 
     def test_parse_electrum_seed(self):
         key = BTC.parse("E:00000000000000000000000000000001")

--- a/tests/keyparser_test.py
+++ b/tests/keyparser_test.py
@@ -44,7 +44,13 @@ class KeyParserTest(unittest.TestCase):
         key = BTC.parse("zpub6mjuZRsjH7htP5ERSBQZbTQDPdJuueG85D4MGRTEg5YyYBKTPbqEGz9iiPmKkCrTn2dMFsp2tgs3MQ1zExvNFTEnHrrABy4dayJk9foR6K9")
         self.assertEqual(key.secret_exponent(), None)
         subkey = key.subkey_for_path("0/0")
-        self.assertEqual(subkey.address(), "bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af")
+        self.assertEqual(subkey.address(), "bc1qz0e8kyqvhr2j4xzlzr2r5rkpxykerv6vdawckn")
+
+    def test_parse_p2wpkh_in_p2sh(self):
+        key = BTC.parse("ypub6XBLL6jnweSSSPTqcwWAs8RXKKuN2FHH7LABWKE6aLoEnw5c2AbEBYSmQytdE1yDQtyJgdmi1K45ytkfDwrksXjefVCHw3thJ4xwyJPJnQk")
+        self.assertEqual(key.secret_exponent(), None)
+        subkey = key.subkey_for_path("0/0")
+        self.assertEqual(subkey.address(), "3Q8QcAFXNRKSWmYDzjYzoZEMNrEf1jXaRG")
 
     def test_parse_wif(self):
         key = BTC.parse("KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn")
@@ -63,8 +69,12 @@ class KeyParserTest(unittest.TestCase):
         self.assertEqual(key, None)
 
     def test_parse_p2wpkh_address(self):
-        key = BTC.parse("bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af")
-        self.assertEqual(key.address(), "bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af")
+        key = BTC.parse("bc1qz0e8kyqvhr2j4xzlzr2r5rkpxykerv6vdawckn")
+        self.assertEqual(key.address(), "bc1qz0e8kyqvhr2j4xzlzr2r5rkpxykerv6vdawckn")
+
+    def test_parse_p2wpkh_in_p2sh_address(self):
+        key = BTC.parse("3Q8QcAFXNRKSWmYDzjYzoZEMNrEf1jXaRG")
+        self.assertEqual(key.address(), "3Q8QcAFXNRKSWmYDzjYzoZEMNrEf1jXaRG")
 
     def test_parse_electrum_seed(self):
         key = BTC.parse("E:00000000000000000000000000000001")

--- a/tests/keyparser_test.py
+++ b/tests/keyparser_test.py
@@ -40,6 +40,12 @@ class KeyParserTest(unittest.TestCase):
                         "ncCKZKgb5jZoY5eSJMJ2Vbyvi2hbmQnCuHBujZ2WXGTux1X2k9Krdtr")
         self.assertEqual(key, None)
 
+    def test_parse_p2wpkh_native(self):
+        key = BTC.parse("zpub6mjuZRsjH7htP5ERSBQZbTQDPdJuueG85D4MGRTEg5YyYBKTPbqEGz9iiPmKkCrTn2dMFsp2tgs3MQ1zExvNFTEnHrrABy4dayJk9foR6K9")
+        self.assertEqual(key.secret_exponent(), None)
+        subkey = key.subkey_for_path("0/0")
+        self.assertEqual(subkey.address(), "bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af")
+
     def test_parse_wif(self):
         key = BTC.parse("KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn")
         self.assertEqual(key.secret_exponent(), 1)
@@ -55,6 +61,10 @@ class KeyParserTest(unittest.TestCase):
     def test_parse_bad_address(self):
         key = BTC.parse("1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMW")
         self.assertEqual(key, None)
+
+    def test_parse_p2wpkh_address(self):
+        key = BTC.parse("bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af")
+        self.assertEqual(key.address(), "bc1q3g5tmkmlvxryhh843v4dz026avatc0zzr6h3af")
 
     def test_parse_electrum_seed(self):
         key = BTC.parse("E:00000000000000000000000000000001")


### PR DESCRIPTION
This is in reference of Issue #251. This PR is based on work done earlier by @shivaenigma and @freenancial

At this point this PR handles yPub/zPub (BIP49 and BIP84) address parsing, but some work in this PR is needed before talking about merge. I am in need of some help structuring the code correctly and I am asking if @richardkiss would have a moment to help me put the final pieces to correct places and correct any possible glaring mistakes I might have done.

What I am thinking is in BIP32Node.py  the overriding `address()` function, especially the P2WPKH-in-P2SH code should be moved to a better location but I am unsure of where.