### PR TITLE
Add segwit xpub to ku

### DIFF
--- a/pycoin/cmds/ku.py
+++ b/pycoin/cmds/ku.py
@@ -43,7 +43,7 @@ def get_entropy():
     return entropy
 
 
-def create_output(item, key, output_key_set, subkey_path=None):
+def create_output(item, key, output_key_set, args, subkey_path=None):
     output_dict = {}
     output_order = []
 
@@ -66,6 +66,18 @@ def create_output(item, key, output_key_set, subkey_path=None):
 
     if subkey_path:
         add_output("subkey_path", subkey_path)
+
+    if args.p2sh_segwit:
+        add_output("p2sh_segwit wallet key",
+            key._network.bip49_as_string(key.serialize(as_private=True), as_private=True))
+        add_output("p2sh_segwit public version",
+            key._network.bip49_as_string(key.serialize(as_private=False), as_private=False))
+
+    if args.segwit:
+        add_output("segwit wallet key",
+            key._network.bip84_as_string(key.serialize(as_private=True), as_private=True))
+        add_output("segwit public version",
+            key._network.bip84_as_string(key.serialize(as_private=False), as_private=False))
 
     for k, v, text in key.ku_output():
         add_output(k, v, text)
@@ -108,6 +120,8 @@ def create_parser():
     parser.add_argument('-b', "--brief", nargs="*", help='brief output; display a single field')
 
     parser.add_argument('-s', "--subkey", help='subkey path (example: 0H/2/15-20)', default="")
+    parser.add_argument("--p2sh-segwit", help='output bitcoin non-native segwit xpub', action='store_true')
+    parser.add_argument("--segwit", help='output bitcoin segwit xpub', action='store_true')
     parser.add_argument('-n', "--network", help='specify network', choices=codes)
     parser.add_argument(
         "--override-network", help='override detected network type', default=None, choices=codes)
@@ -218,7 +232,7 @@ def ku(args, parser):
             if args.public:
                 key = key.public_copy()
 
-            output_dict, output_order = create_output(item, key, output_key_set)
+            output_dict, output_order = create_output(item, key, output_key_set, args)
 
             generate_output(args, output_dict, output_order)
 

--- a/pycoin/networks/bitcoinish.py
+++ b/pycoin/networks/bitcoinish.py
@@ -235,6 +235,7 @@ def create_bitcoinish_network(symbol, network_name, subnet_name, **kwargs):
 
     network.bip32_as_string = bip32_as_string
     network.bip49_as_string = bip49_as_string
+    network.bip84_as_string = bip84_as_string
     network.sec_text_for_blob = sec_text_for_blob
     network.wif_for_blob = wif_for_blob
 


### PR DESCRIPTION
This adds the option to get ku output also for Bitcoin BIP49 p2sh segwit and BIP84 segwit xPubs

Can be considered if the `bipxx_as_string` codes would be better in HierarchialKey