### PR TITLE
removed the redundant __str__ method

### DIFF
--- a/pycoin/encoding/hexbytes.py
+++ b/pycoin/encoding/hexbytes.py
@@ -31,7 +31,17 @@ class bytes_as_revhex(bytes):
     def __repr__(self):
         return b2h_rev(self)
 
+    # both __repr__ and __str__ must be overloaded as bytes implements both.
+    # see https://github.com/richardkiss/pycoin/pull/407
+    def __str__(self):
+        return self.__repr__()
+
 
 class bytes_as_hex(bytes):
     def __repr__(self):
         return b2h(self)
+
+    # both __repr__ and __str__ must be overloaded as bytes implements both.
+    # see https://github.com/richardkiss/pycoin/pull/407
+    def __str__(self):
+        return self.__repr__()

--- a/pycoin/encoding/hexbytes.py
+++ b/pycoin/encoding/hexbytes.py
@@ -28,16 +28,10 @@ def b2h_rev(the_bytes):
 
 
 class bytes_as_revhex(bytes):
-    def __str__(self):
-        return b2h_rev(self)
-
     def __repr__(self):
         return b2h_rev(self)
 
 
 class bytes_as_hex(bytes):
-    def __str__(self):
-        return b2h(self)
-
     def __repr__(self):
         return b2h(self)


### PR DESCRIPTION
Just removing the redundant `__str__` method as the `__repr__` method is already implemented and contains the same code block.