### PR TITLE
Add future annotations import to Generator.py

### DIFF
--- a/pycoin/ecdsa/Generator.py
+++ b/pycoin/ecdsa/Generator.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from typing import Callable
 


### PR DESCRIPTION
Current version causes `NameError: name 'Generator' is not defined` because [`Generator.__new__`](https://github.com/richardkiss/pycoin/blob/main/pycoin/ecdsa/Generator.py#L26) uses a self-referential return annotation.  ( -> Generator )

I added `from __future__ import annotations` to `pycoin/ecdsa/Generator.py` to postpone annotation evaluation and prevent the crash. I am using Python 3.12.3.